### PR TITLE
Fix VcsSupport import and PackageFinder test

### DIFF
--- a/.azure-pipelines/templates/build-package.yml
+++ b/.azure-pipelines/templates/build-package.yml
@@ -7,7 +7,7 @@ steps:
   - template: install-dependencies.yml
 
   - script: |
-      pip install invoke towncrier readme-renderer[md] twine
+      pip install invoke towncrier readme-renderer[md] twine parver
       inv clean
       inv build
       twine check dist/*

--- a/.azure-pipelines/templates/install-dependencies.yml
+++ b/.azure-pipelines/templates/install-dependencies.yml
@@ -1,6 +1,6 @@
 steps:
   - script: |
-      python -m pip install $(PIP_VERSION)
+      python -m pip install --upgrade pip
       python -m pip install setuptools wheel pytest-xdist pytest-cov pytest-timeout --upgrade
       python -m pip install -e .[tests]
     displayName: Install Dependencies

--- a/.azure-pipelines/templates/install-dependencies.yml
+++ b/.azure-pipelines/templates/install-dependencies.yml
@@ -1,6 +1,6 @@
 steps:
   - script: |
-      python -m pip install $(PIP_VERSION) --ignore-installed
+      python -m pip install $(PIP_VERSION)
       python -m pip install setuptools wheel pytest-xdist pytest-cov pytest-timeout --upgrade
       python -m pip install -e .[tests]
     displayName: Install Dependencies

--- a/.azure-pipelines/templates/reinstall-pythons.yml
+++ b/.azure-pipelines/templates/reinstall-pythons.yml
@@ -8,7 +8,7 @@ steps:
       rm -rf $AGENT_TOOLSDIRECTORY/Python/2.7.16
       rm -rf $AGENT_TOOLSDIRECTORY/Python/3.5.7
       rm -rf $AGENT_TOOLSDIRECTORY/Python/3.7.3
-
+      [ -e $AGENT_TOOLSDIRECTORY/Python/3.7.2 ] && [ -e $AGENT_TOOLSDIRECTORY/Python/3.5.5 ] && [ -e $AGENT_TOOLSDIRECTORY/Python/2.7.15 ] && return 0
       # Download new Pythons
       azcopy --recursive \
         --source https://vstsagenttools.blob.core.windows.net/tools/hostedtoolcache/linux/Python/2.7.15 \

--- a/.azure-pipelines/templates/reinstall-pythons.yml
+++ b/.azure-pipelines/templates/reinstall-pythons.yml
@@ -1,0 +1,34 @@
+steps:
+  - script: |
+      # When you paste this, please make sure the indentation is preserved
+      # Fail out if any setups fail
+      set -e
+
+      # Delete old Pythons
+      rm -rf $AGENT_TOOLSDIRECTORY/Python/2.7.16
+      rm -rf $AGENT_TOOLSDIRECTORY/Python/3.5.7
+      rm -rf $AGENT_TOOLSDIRECTORY/Python/3.7.3
+
+      # Download new Pythons
+      azcopy --recursive \
+        --source https://vstsagenttools.blob.core.windows.net/tools/hostedtoolcache/linux/Python/2.7.15 \
+        --destination $AGENT_TOOLSDIRECTORY/Python/2.7.15
+
+      azcopy --recursive \
+        --source https://vstsagenttools.blob.core.windows.net/tools/hostedtoolcache/linux/Python/3.5.5 \
+        --destination $AGENT_TOOLSDIRECTORY/Python/3.5.5
+
+      azcopy --recursive \
+        --source https://vstsagenttools.blob.core.windows.net/tools/hostedtoolcache/linux/Python/3.7.2 \
+        --destination $AGENT_TOOLSDIRECTORY/Python/3.7.2
+
+      # Install new Pythons
+      original_directory=$PWD
+      setups=$(find $AGENT_TOOLSDIRECTORY/Python -name setup.sh)
+      for setup in $setups; do
+          chmod +x $setup;
+          cd $(dirname $setup);
+          ./$(basename $setup);
+          cd $original_directory;
+      done;
+    displayName: 'Workaround: roll back Python versions'

--- a/.azure-pipelines/templates/reinstall-pythons.yml
+++ b/.azure-pipelines/templates/reinstall-pythons.yml
@@ -8,7 +8,7 @@ steps:
       rm -rf $AGENT_TOOLSDIRECTORY/Python/2.7.16
       rm -rf $AGENT_TOOLSDIRECTORY/Python/3.5.7
       rm -rf $AGENT_TOOLSDIRECTORY/Python/3.7.3
-      [ -e $AGENT_TOOLSDIRECTORY/Python/3.7.2 ] && [ -e $AGENT_TOOLSDIRECTORY/Python/3.5.5 ] && [ -e $AGENT_TOOLSDIRECTORY/Python/2.7.15 ] && return 0
+      [ -e $AGENT_TOOLSDIRECTORY/Python/3.7.2 ] && [ -e $AGENT_TOOLSDIRECTORY/Python/3.5.5 ] && [ -e $AGENT_TOOLSDIRECTORY/Python/2.7.15 ] && exit 0
       # Download new Pythons
       azcopy --recursive \
         --source https://vstsagenttools.blob.core.windows.net/tools/hostedtoolcache/linux/Python/2.7.15 \

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -28,37 +28,48 @@ jobs:
       versionSpec: $(python.version)
     displayName: Use Python $(python.version)
 
-  - ${{ if eq(parameters.vmImage, 'windows-2019') }}:
-    - powershell: |
-        python -m pip install virtualenv --upgrade
-        python -m virtualenv .venv
-        . .venv/Scripts/activate.ps1
-        ./.venv/Scripts/pip install $(PIP_VERSION) setuptools wheel pytest-xdist pytest-cov pytest-timeout -e .[tests] --upgrade
-      displayName: Install Dependencies
-      env:
-        PYTHONWARNINGS: ignore:DEPRECATION
-    - powershell: |
-        . .venv/Scripts/activate.ps1
-        pytest -ra --junitxml=junit/test-results.xml tests/
-      displayName: 'Run Pytest'
-      env:
-        PYTHONWARNINGS: ignore:DEPRECATION
+  - script: |
+      python -m pip install pipenv
+      python -m pipenv run pip install $(PIP_VERSION) --upgrade
+      pipenv install --dev
+    displayName: 'Install Dependencies'
+    env:
+      PYTHONWARNINGS: ignore:DEPRECATION
+  - script: pipenv run pytest -ra --junitxml=junit/test-results.xml tests/
+    displayName: 'Run PyTest'
+    env:
+      PYTHONWARNINGS: ignore:DEPRECATION
+#   - ${{ if eq(parameters.vmImage, 'windows-2019') }}:
+#     - powershell: |
+#         python -m pip install virtualenv --upgrade
+#         python -m virtualenv .venv
+#         . .venv/Scripts/activate.ps1
+#         ./.venv/Scripts/pip install $(PIP_VERSION) setuptools wheel pytest-xdist pytest-cov pytest-timeout -e .[tests] --upgrade
+#       displayName: Install Dependencies
+#       env:
+#         PYTHONWARNINGS: ignore:DEPRECATION
+#     - powershell: |
+#         . .venv/Scripts/activate.ps1
+#         pytest -ra --junitxml=junit/test-results.xml tests/
+#       displayName: 'Run Pytest'
+#       env:
+#         PYTHONWARNINGS: ignore:DEPRECATION
 
-  - ${{ if ne(parameters.vmImage, 'windows-2019') }}:
-    - script: |
-        python -m pip install virtualenv --upgrade
-        python -m virtualenv .venv
-        . ./.venv/bin/activate && \
-            PATH="$(pwd)/.venv/bin:${PATH}" ./.venv/bin/python -m pip install $(PIP_VERSION) setuptools wheel pytest-xdist pytest-cov pytest-timeout -e .[tests] --upgrade
-      displayName: Install Dependencies
-      env:
-        PYTHONWARNINGS: ignore:DEPRECATION
-    - script: |
-        . ./.venv/bin/activate && \
-            PATH="$(pwd)/.venv/bin:${PATH}" ./.venv/bin/python -m pytest -ra --junitxml=junit/test-results.xml tests/
-      displayName: 'Run Pytest'
-      env:
-        PYTHONWARNINGS: ignore:DEPRECATION
+#   - ${{ if ne(parameters.vmImage, 'windows-2019') }}:
+#     - script: |
+#         python -m pip install virtualenv --upgrade
+#         python -m virtualenv .venv
+#         . ./.venv/bin/activate && \
+#             PATH="$(pwd)/.venv/bin:${PATH}" ./.venv/bin/python -m pip install $(PIP_VERSION) setuptools wheel pytest-xdist pytest-cov pytest-timeout -e .[tests] --upgrade
+#       displayName: Install Dependencies
+#       env:
+#         PYTHONWARNINGS: ignore:DEPRECATION
+#     - script: |
+#         . ./.venv/bin/activate && \
+#             PATH="$(pwd)/.venv/bin:${PATH}" ./.venv/bin/python -m pytest -ra --junitxml=junit/test-results.xml tests/
+#       displayName: 'Run Pytest'
+#       env:
+#         PYTHONWARNINGS: ignore:DEPRECATION
 
   - task: PublishTestResults@2
     inputs:

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -28,6 +28,9 @@ jobs:
       versionSpec: $(python.version)
     displayName: Use Python $(python.version)
 
+  - ${{ if eq(parameters.vmImage, 'ubuntu-16.04') }}:
+    - template: ./reinstall-pythons.yml
+
   - script: |
       python -m pip install pipenv
       python -m pipenv run pip install $(PIP_VERSION) --upgrade

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -29,7 +29,7 @@ jobs:
     displayName: Use Python $(python.version)
 
   - script: |
-      python -m pip install $(PIP_VERSION) --ignore-installed
+      python -m pip install $(PIP_VERSION)
       python -m pip install setuptools wheel pytest-xdist pytest-cov pytest-timeout --upgrade
       python -m pip install -e .[tests]
     displayName: Install Dependencies

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -23,13 +23,13 @@ jobs:
   variables:
   - group: CI
   steps:
+  - ${{ if eq(parameters.vmImage, 'ubuntu-16.04') }}:
+    - template: ./reinstall-pythons.yml
+
   - task: UsePythonVersion@0
     inputs:
       versionSpec: $(python.version)
     displayName: Use Python $(python.version)
-
-  - ${{ if eq(parameters.vmImage, 'ubuntu-16.04') }}:
-    - template: ./reinstall-pythons.yml
 
   - script: |
       python -m pip install pipenv

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -15,11 +15,11 @@ jobs:
           ${{ if contains(pip, 'github.com') }}:
             ${{ format('{0}-PIPMaster', py) }}:
               python.version: ${{ py }}
-              PIP_VERSION: ${{ pip }}
+              INSTALL_PIP_VERSION: ${{ pip }}
           ${{ if not(contains(pip, 'github.com')) }}:
             ${{ format('{0}{1}', py, pip) }}:
               python.version: ${{ py }}
-              PIP_VERSION: ${{ pip }}
+              INSTALL_PIP_VERSION: ${{ pip }}
   variables:
   - group: CI
   steps:
@@ -33,7 +33,7 @@ jobs:
 
   - script: |
       python -m pip install pipenv
-      python -m pipenv run pip install $(PIP_VERSION) --upgrade
+      python -m pipenv run pip install $(INSTALL_PIP_VERSION) --upgrade
       pipenv install --dev
     displayName: 'Install Dependencies'
     env:

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -28,7 +28,7 @@ jobs:
       versionSpec: $(python.version)
     displayName: Use Python $(python.version)
 
-  ${{ if eq(parameters.vmImage, 'windows-2019') }}:
+  - ${{ if eq(parameters.vmImage, 'windows-2019') }}:
     - powershell: |
         python -m pip install virtualenv --upgrade
         python -m virtualenv .venv
@@ -37,7 +37,12 @@ jobs:
         python -m pip install setuptools wheel pytest-xdist pytest-cov pytest-timeout --upgrade
         python -m pip install -e .[tests]
       displayName: Install Dependencies
-  ${{ if ne(parameters.vmImage, 'windows-2019') }}:
+    - powershell: |
+       source .venv/Scripts/activate.ps1
+       pytest -ra --junitxml=junit/test-results.xml tests/
+      displayName: 'Run Pytest'
+
+  - ${{ if ne(parameters.vmImage, 'windows-2019') }}:
     - script: |
         python -m pip install virtualenv --upgrade
         python -m virtualenv .venv
@@ -46,13 +51,6 @@ jobs:
         python -m pip install setuptools wheel pytest-xdist pytest-cov pytest-timeout --upgrade
         python -m pip install -e .[tests]
       displayName: Install Dependencies
-
-  ${{ if eq(parameters.vmImage, 'windows-2019') }}:
-    - powershell: |
-       source .venv/Scripts/activate.ps1
-       pytest -ra --junitxml=junit/test-results.xml tests/
-      displayName: 'Run Pytest'
-  ${{ if ne(parameters.vmImage, 'windows-2019') }}:
     - script: |
        source .venv/bin/activate
        pytest -ra --junitxml=junit/test-results.xml tests/

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -33,9 +33,7 @@ jobs:
         python -m pip install virtualenv --upgrade
         python -m virtualenv .venv
         . .venv/Scripts/activate.ps1
-        python -m pip install $(PIP_VERSION)
-        python -m pip install setuptools wheel pytest-xdist pytest-cov pytest-timeout --upgrade
-        python -m pip install -e .[tests]
+        ./.venv/Scripts/pip install $(PIP_VERSION) setuptools wheel pytest-xdist pytest-cov pytest-timeout -e .[tests] --upgrade
       displayName: Install Dependencies
     - powershell: |
         . .venv/Scripts/activate.ps1
@@ -47,9 +45,7 @@ jobs:
         python -m pip install virtualenv --upgrade
         python -m virtualenv .venv
         . .venv/bin/activate && \
-            python -m pip install $(PIP_VERSION) &&
-            python -m pip install setuptools wheel pytest-xdist pytest-cov pytest-timeout --upgrade && \
-            python -m pip install -e .[tests]
+            ./.venv/bin/pip install $(PIP_VERSION) setuptools wheel pytest-xdist pytest-cov pytest-timeout -e .[tests] --upgrade
       displayName: Install Dependencies
     - script: |
         . .venv/bin/activate && \

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -1,7 +1,7 @@
 parameters:
   pythonVersions: []
   pipVersions: []
-  vmImageName: ''
+  vmImage: ''
   jobName: ''
 
 jobs:
@@ -28,14 +28,35 @@ jobs:
       versionSpec: $(python.version)
     displayName: Use Python $(python.version)
 
-  - script: |
-      python -m pip install $(PIP_VERSION)
-      python -m pip install setuptools wheel pytest-xdist pytest-cov pytest-timeout --upgrade
-      python -m pip install -e .[tests]
-    displayName: Install Dependencies
+  ${{ if eq(parameters.vmImage, 'windows-2019') }}:
+    - powershell: |
+        python -m pip install virtualenv --upgrade
+        python -m virtualenv .venv
+        source .venv/Scripts/activate.ps1
+        python -m pip install $(PIP_VERSION)
+        python -m pip install setuptools wheel pytest-xdist pytest-cov pytest-timeout --upgrade
+        python -m pip install -e .[tests]
+      displayName: Install Dependencies
+  ${{ if ne(parameters.vmImage, 'windows-2019') }}:
+    - script: |
+        python -m pip install virtualenv --upgrade
+        python -m virtualenv .venv
+        source .venv/bin/activate
+        python -m pip install $(PIP_VERSION)
+        python -m pip install setuptools wheel pytest-xdist pytest-cov pytest-timeout --upgrade
+        python -m pip install -e .[tests]
+      displayName: Install Dependencies
 
-  - script: pytest -ra --junitxml=junit/test-results.xml tests/
-    displayName: 'Run Pytest'
+  ${{ if eq(parameters.vmImage, 'windows-2019') }}:
+    - powershell: |
+       source .venv/Scripts/activate.ps1
+       pytest -ra --junitxml=junit/test-results.xml tests/
+      displayName: 'Run Pytest'
+  ${{ if ne(parameters.vmImage, 'windows-2019') }}:
+    - script: |
+       source .venv/bin/activate
+       pytest -ra --junitxml=junit/test-results.xml tests/
+      displayName: 'Run Pytest'
 
   - task: PublishTestResults@2
     inputs:

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -32,28 +32,28 @@ jobs:
     - powershell: |
         python -m pip install virtualenv --upgrade
         python -m virtualenv .venv
-        source .venv/Scripts/activate.ps1
+        . .venv/Scripts/activate.ps1
         python -m pip install $(PIP_VERSION)
         python -m pip install setuptools wheel pytest-xdist pytest-cov pytest-timeout --upgrade
         python -m pip install -e .[tests]
       displayName: Install Dependencies
     - powershell: |
-       source .venv/Scripts/activate.ps1
-       pytest -ra --junitxml=junit/test-results.xml tests/
+        . .venv/Scripts/activate.ps1
+        pytest -ra --junitxml=junit/test-results.xml tests/
       displayName: 'Run Pytest'
 
   - ${{ if ne(parameters.vmImage, 'windows-2019') }}:
     - script: |
         python -m pip install virtualenv --upgrade
         python -m virtualenv .venv
-        source .venv/bin/activate
-        python -m pip install $(PIP_VERSION)
-        python -m pip install setuptools wheel pytest-xdist pytest-cov pytest-timeout --upgrade
-        python -m pip install -e .[tests]
+        . .venv/bin/activate && \
+            python -m pip install $(PIP_VERSION) &&
+            python -m pip install setuptools wheel pytest-xdist pytest-cov pytest-timeout --upgrade && \
+            python -m pip install -e .[tests]
       displayName: Install Dependencies
     - script: |
-       source .venv/bin/activate
-       pytest -ra --junitxml=junit/test-results.xml tests/
+        . .venv/bin/activate && \
+            pytest -ra --junitxml=junit/test-results.xml tests/
       displayName: 'Run Pytest'
 
   - task: PublishTestResults@2

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -35,10 +35,14 @@ jobs:
         . .venv/Scripts/activate.ps1
         ./.venv/Scripts/pip install $(PIP_VERSION) setuptools wheel pytest-xdist pytest-cov pytest-timeout -e .[tests] --upgrade
       displayName: Install Dependencies
+      env:
+        PYTHONWARNINGS: ignore:DEPRECATION
     - powershell: |
         . .venv/Scripts/activate.ps1
         pytest -ra --junitxml=junit/test-results.xml tests/
       displayName: 'Run Pytest'
+      env:
+        PYTHONWARNINGS: ignore:DEPRECATION
 
   - ${{ if ne(parameters.vmImage, 'windows-2019') }}:
     - script: |
@@ -47,10 +51,14 @@ jobs:
         . .venv/bin/activate && \
             ./.venv/bin/pip install $(PIP_VERSION) setuptools wheel pytest-xdist pytest-cov pytest-timeout -e .[tests] --upgrade
       displayName: Install Dependencies
+      env:
+        PYTHONWARNINGS: ignore:DEPRECATION
     - script: |
         . .venv/bin/activate && \
             pytest -ra --junitxml=junit/test-results.xml tests/
       displayName: 'Run Pytest'
+      env:
+        PYTHONWARNINGS: ignore:DEPRECATION
 
   - task: PublishTestResults@2
     inputs:

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -33,7 +33,7 @@ jobs:
 
   - script: |
       python -m pip install pipenv
-      python -m pipenv run pip install $(INSTALL_PIP_VERSION) --upgrade
+      python -m pipenv run python -m pip install $(INSTALL_PIP_VERSION) --upgrade
       pipenv install --dev
     displayName: 'Install Dependencies'
     env:

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -48,14 +48,14 @@ jobs:
     - script: |
         python -m pip install virtualenv --upgrade
         python -m virtualenv .venv
-        . .venv/bin/activate && \
-            ./.venv/bin/pip install $(PIP_VERSION) setuptools wheel pytest-xdist pytest-cov pytest-timeout -e .[tests] --upgrade
+        . ./.venv/bin/activate && \
+            PATH="$(pwd)/.venv/bin:${PATH}" ./.venv/bin/python -m pip install $(PIP_VERSION) setuptools wheel pytest-xdist pytest-cov pytest-timeout -e .[tests] --upgrade
       displayName: Install Dependencies
       env:
         PYTHONWARNINGS: ignore:DEPRECATION
     - script: |
-        . .venv/bin/activate && \
-            pytest -ra --junitxml=junit/test-results.xml tests/
+        . ./.venv/bin/activate && \
+            PATH="$(pwd)/.venv/bin:${PATH}" ./.venv/bin/python -m pytest -ra --junitxml=junit/test-results.xml tests/
       displayName: 'Run Pytest'
       env:
         PYTHONWARNINGS: ignore:DEPRECATION

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -42,37 +42,6 @@ jobs:
     displayName: 'Run PyTest'
     env:
       PYTHONWARNINGS: ignore:DEPRECATION
-#   - ${{ if eq(parameters.vmImage, 'windows-2019') }}:
-#     - powershell: |
-#         python -m pip install virtualenv --upgrade
-#         python -m virtualenv .venv
-#         . .venv/Scripts/activate.ps1
-#         ./.venv/Scripts/pip install $(PIP_VERSION) setuptools wheel pytest-xdist pytest-cov pytest-timeout -e .[tests] --upgrade
-#       displayName: Install Dependencies
-#       env:
-#         PYTHONWARNINGS: ignore:DEPRECATION
-#     - powershell: |
-#         . .venv/Scripts/activate.ps1
-#         pytest -ra --junitxml=junit/test-results.xml tests/
-#       displayName: 'Run Pytest'
-#       env:
-#         PYTHONWARNINGS: ignore:DEPRECATION
-
-#   - ${{ if ne(parameters.vmImage, 'windows-2019') }}:
-#     - script: |
-#         python -m pip install virtualenv --upgrade
-#         python -m virtualenv .venv
-#         . ./.venv/bin/activate && \
-#             PATH="$(pwd)/.venv/bin:${PATH}" ./.venv/bin/python -m pip install $(PIP_VERSION) setuptools wheel pytest-xdist pytest-cov pytest-timeout -e .[tests] --upgrade
-#       displayName: Install Dependencies
-#       env:
-#         PYTHONWARNINGS: ignore:DEPRECATION
-#     - script: |
-#         . ./.venv/bin/activate && \
-#             PATH="$(pwd)/.venv/bin:${PATH}" ./.venv/bin/python -m pytest -ra --junitxml=junit/test-results.xml tests/
-#       displayName: 'Run Pytest'
-#       env:
-#         PYTHONWARNINGS: ignore:DEPRECATION
 
   - task: PublishTestResults@2
     inputs:

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,5 @@ venv.bak/
 .mypy_cache/
 
 .vscode
+XDG_CACHE_HOME/
+pip-wheel-metadata/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,10 +13,10 @@ exclude azure-pipelines.yml
 
 recursive-include docs Makefile *.rst *.py *.bat
 recursive-exclude docs requirements*.txt
-recursive-exclude .azure-pipelines *.yml
 
 prune .github
 prune docs/build
 prune news
 prune tasks
 prune tests
+prune .azure-pipelines

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -38,11 +38,11 @@
         },
         "aspy.yaml": {
             "hashes": [
-                "sha256:ae249074803e8b957c83fdd82a99160d0d6d26dff9ba81ba608b42eebd7d8cd3",
-                "sha256:c7390d79f58eb9157406966201abf26da0d56c07e0ff0deadc39c8f4dbc13482"
+                "sha256:463372c043f70160a9ec950c3f1e4c3a82db5fca01d334b6bc89c7164d744bdc",
+                "sha256:e7c742382eff2caed61f87a39d13f99109088e5e93f04d76eb8d4b28aa143f45"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.2.0"
+            "version": "==1.3.0"
         },
         "atomicwrites": {
             "hashes": [
@@ -117,11 +117,11 @@
         },
         "cfgv": {
             "hashes": [
-                "sha256:6e9f2feea5e84bc71e56abd703140d7a2c250fc5ba38b8702fd6a68ed4e3b2ef",
-                "sha256:e7f186d4a36c099a9e20b04ac3108bd8bb9b9257e692ce18c8c3764d5cb12172"
+                "sha256:32edbe09de6f4521224b87822103a8c16a614d31a894735f7a5b3bcf0eb3c37e",
+                "sha256:3bd31385cd2bebddbba8012200aaf15aa208539f1b33973759b4d02fc2148da5"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.6.0"
+            "version": "==2.0.0"
         },
         "chardet": {
             "hashes": [
@@ -188,48 +188,44 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:029c69deaeeeae1b15bc6c59f0ffa28aa8473721c614a23f2c2976dec245cd12",
-                "sha256:02abbbebc6e9d5abe13cd28b5e963dedb6ffb51c146c916d17b18f141acd9947",
-                "sha256:0384e4479aeb780bfb811eb54c3deb37dbc5e197cd19ec1190cb4b33b254f661",
-                "sha256:1bbfe5b82a3921d285e999c6d256c1e16b31c554c29da62d326f86c173d30337",
-                "sha256:20bbeef0d08e43ef44e10d5863225e178fe100d5778c616260286202bad9d2b4",
-                "sha256:210c02f923df33a8d0e461c86fdcbbb17228ff4f6d92609fc06370a98d283c2d",
-                "sha256:2d0807ba935f540d20b49d5bf1c0237b90ce81e133402feda906e540003f2f7a",
-                "sha256:35d7a013874a7c927ce997350d314144ffc5465faf787bb4e46e6c4f381ef562",
-                "sha256:3636f9d0dcb01aed4180ef2e57a4e34bb4cac3ecd203c2a23db8526d86ab2fb4",
-                "sha256:42f4be770af2455a75e4640f033a82c62f3fb0d7a074123266e143269d7010ef",
-                "sha256:48440b25ba6cda72d4c638f3a9efa827b5b87b489c96ab5f4ff597d976413156",
-                "sha256:494fc6f09b776668cb0d69df5caefb9b90867bd280eb1bd004a63c79fbb09e71",
-                "sha256:4dac8dfd1acf6a3ac657475dfdc66c621f291b1b7422a939cc33c13ac5356473",
-                "sha256:4e8474771c69c2991d5eab65764289a7dd450bbea050bc0ebb42b678d8222b42",
-                "sha256:551f10ddfeff56a1325e5a34eff304c5892aa981fd810babb98bfee77ee2fb17",
-                "sha256:5b104982f1809c1577912519eb249f17d9d7e66304ad026666cb60a5ef73309c",
-                "sha256:5c62aef73dfc87bfcca32cee149a1a7a602bc74bac72223236b0023543511c88",
-                "sha256:633151f8d1ad9467b9f7e90854a7f46ed8f2919e8bc7d98d737833e8938fc081",
-                "sha256:772207b9e2d5bf3f9d283b88915723e4e92d9a62c83f44ec92b9bd0cd685541b",
-                "sha256:7d5e02f647cd727afc2659ec14d4d1cc0508c47e6cfb07aea33d7aa9ca94d288",
-                "sha256:8edc25c1449bdf31acfe183e579bb9c75cec59b55220ccefb6a4f960807ef1d0",
-                "sha256:96d895fba9ed55286368bd4626b8dcbf19b9a529a88e5a6b5c22e0b08c95852a",
-                "sha256:a77589fec63dc7fa6469d8cd122cc285ec034be43d8a2ba600020ddb14277514",
-                "sha256:a9798a4111abb0f94584000ba2a2c74841f2cfe5f9254709756367aabbae0541",
-                "sha256:b33a8f3d6d8946ea1db4ec228606ebc45cf880a7b1d1a26fe8790af677c12b8b",
-                "sha256:b38ea741ab9e35bfa7015c93c93bbd6a1623428f97a67083fc8ebd366238b91f",
-                "sha256:b6a5478c904236543c0347db8a05fac6fc0bd574c870e7970faa88e1d9890044",
-                "sha256:c6248bfc1de36a3844685a2e10ba17c18119ba6252547f921062a323fb31bff1",
-                "sha256:c6c6f84282d3f8953072295ce5cb96cdc56c91f164ef451a5c03be8abb84ad56",
-                "sha256:c705ab445936457359b1424ef25ccc0098b0491b26064677c39f1d14a539f056",
-                "sha256:d95a363d663ceee647291131dbd213af258df24f41350246842481ec3709bd33",
-                "sha256:e27265eb80cdc5dab55a40ef6f890e04ecc618649ad3da5265f128b141f93f78",
-                "sha256:eb62a45b448258bd8b9faa2d12dc2b942259715d7e0d85ebbb3d737be83091d7",
-                "sha256:ebc276c9cb5d917bd2ae959f84ffc279acafa9c9b50b0fa436ebb70bbe2166ea",
-                "sha256:f05a38b77b6c62cff204b0874034d76709769b53a8a7fc5886e02fc4d099d540",
-                "sha256:f4d229866d030863d0fe3bf297d6d11e6133ca15bbb41ed2534a8b9a3d6bd061",
-                "sha256:f95675bd88b51474d4fe5165f3266f419ce754ffadfb97f10323931fa9ac95e5",
-                "sha256:f95bc54fb6d61b9f9ff09c4ae8ff6a3f5edc937cda3ca36fc937302a7c152bf1",
-                "sha256:fd0f6be53de40683584e5331c341e65a679dbe5ec489a0697cec7c2ef1a48cda"
+                "sha256:0402b1822d513d0231589494bceddb067d20581f5083598c451b56c684b0e5d6",
+                "sha256:0644e28e8aea9d9d563607ee8b7071b07dd57a4a3de11f8684cd33c51c0d1b93",
+                "sha256:0874a283686803884ec0665018881130604956dbaa344f2539c46d82cbe29eda",
+                "sha256:0988c3837df4bc371189bb3425d5232cf150055452034c232dda9cbe04f9c38e",
+                "sha256:0eb07cf2ec7e3418eda340be98fbdccdede8e6b26701f30956b1d482284fddd5",
+                "sha256:20bc3205b3100956bb72293fabb97f0ed972c81fed10b3251c90c70dcb0599ab",
+                "sha256:2cc9142a3367e74eb6b19d58c53ebb1dfd7336b91cdcc91a6a2888bf8c7af984",
+                "sha256:3ae9a0a59b058ce0761c3bd2c2d66ecb2ee2b8ac592620184370577f7a546fb3",
+                "sha256:3b2e30b835df58cb973f478d09f3d82e90c98c8e5059acc245a8e4607e023801",
+                "sha256:401e9b04894eb1498c639c6623ee78a646990ce5f095248e2440968aafd6e90e",
+                "sha256:41ec5812d5decdaa72708be3018e7443e90def4b5a71294236a4df192cf9eab9",
+                "sha256:475769b638a055e75b3d3219e054fe2a023c0b077ff15bff6c95aba7e93e6cac",
+                "sha256:4e11903274680619b598f2e3a5ce714375e31d50f6275c385ba5f15cc7bfa18d",
+                "sha256:5a6424022dedd503ce98925ea745bc8ffdeea9161d66d019f314ec252589d052",
+                "sha256:61424f4e2e82c4129a4ba71e10ebacb32a9ecd6f80de2cd05bdead6ba75ed736",
+                "sha256:68eebc666b36e907b86092e8f50c6f526ee5ab8001932cd4ec094ad764c46edd",
+                "sha256:769ff06571b7bc46abc46e770077056e706176e5342f2cfb3722737ffa88d061",
+                "sha256:811969904d4dd0bee7d958898be8d9d75cef672d9b7e7db819dfeac3d20d2d0c",
+                "sha256:86224bb99abfd672bf2f9fcecad5e8d7a3fa94f7f71513f2210460a0350307cd",
+                "sha256:9a238a20a3af00665f8381f7e53e9c606f9bb652d2423f6b822f6cb790d887e8",
+                "sha256:a23b3fbc14d4e6182ecebfd22f3729beef0636d151d94764a1c28330d185e4e5",
+                "sha256:ac162b4ebe51b7a2b7f5e462c4402802633eb81e77c94f8a7c1ed8a556e72c75",
+                "sha256:b6187378726c84365bf297b5dcdae8789b6a5823b200bea23797777e5a63be09",
+                "sha256:bcd5723d905ed4a825f17410a53535f880b6d7548ae3d89078db7b1ceefcd853",
+                "sha256:c48a4f9c5fb385269bb7fbaf9c1326a94863b65ec7f5c96b2ea56b252f01ad08",
+                "sha256:cd40199d6f1c29c85b170d25589be9a97edff8ee7e62be180a2a137823896030",
+                "sha256:d1bc331a7d069485ac1d8c25a0ea1f6aab6cb2a87146fb652222481c1bddc9ff",
+                "sha256:d7e0cdc249aa0f94aa2e531b03999ddaf03a10b4fa090a894712d4c8066abd89",
+                "sha256:dd47abdf45563e1cfe29274fc79dee78f2fb7ec0a14b1121e18f29dcd36cab55",
+                "sha256:e9d0405377e3bb1fdb5620a866809aedd895fe284032407c03c30e42adb9f307",
+                "sha256:e9ee8fcd8e067fcc5d7276d46e07e863102b70a52545ef4254df1ff0893ce75f",
+                "sha256:eb313c23d983b7810504f42104e8dcd1c7ccdda8fbaab82aab92ab79fea19345",
+                "sha256:f9cfd478654b509941b85ed70f870f5e3c74678f566bec12fd26545e5340ba47",
+                "sha256:fae1fa144034d021a52cb9ea200eb8dedf91869c6df8202ad5d149b41ed91cc8",
+                "sha256:fc2f4c0824b13f580fccdac6352b8b999c9aa52e2c3a2451baf55e5f1e26681b"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3' and python_version < '4'",
-            "version": "==5.0a4"
+            "version": "==5.0a5"
         },
         "docutils": {
             "hashes": [
@@ -281,11 +277,11 @@
         },
         "identify": {
             "hashes": [
-                "sha256:443f419ca6160773cbaf22dbb302b1e436a386f23129dbb5482b68a147c2eca9",
-                "sha256:bd7f15fe07112b713fb68fbdde3a34dd774d9062128f2c398104889f783f989d"
+                "sha256:0a11379b46d06529795442742a043dc2fa14cd8c995ae81d1febbc5f1c014c87",
+                "sha256:43a5d24ffdb07bc7e21faf68b08e9f526a1f41f0056073f480291539ef961dfd"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.4.2"
+            "version": "==1.4.5"
         },
         "idna": {
             "hashes": [
@@ -303,11 +299,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:46fc60c34b6ed7547e2a723fc8de6dc2e3a1173f8423246b3ce497f064e9c3de",
-                "sha256:bc136180e961875af88b1ab85b4009f4f1278f8396a60526c0009f503a1a96ca"
+                "sha256:6dfd58dfe281e8d240937776065dd3624ad5469c835248219bd16cf2e12dbeb7",
+                "sha256:cb6ee23b46173539939964df59d3d72c3e0c1b5d54b84f1d8a7e912fe43612db"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.9"
+            "version": "==0.18"
         },
         "incremental": {
             "hashes": [
@@ -326,11 +322,11 @@
         },
         "isort": {
             "hashes": [
-                "sha256:01cb7e1ca5e6c5b3f235f0385057f70558b70d2f00320208825fa62887292f43",
-                "sha256:268067462aed7eb2a1e237fcb287852f22077de3fb07964e87e00f829eea2d1a"
+                "sha256:c40744b6bc5162bbb39c1257fe298b7a393861d50978b565f3ccd9cb9de0182a",
+                "sha256:f57abacd059dc3bd666258d1efb0377510a89777fda3e3274e3c01f7c03ae22d"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==4.3.17"
+            "version": "==4.3.20"
         },
         "jinja2": {
             "hashes": [
@@ -420,6 +416,14 @@
             "markers": "python_version >= '3.5'",
             "version": "==1.3.3"
         },
+        "packaging": {
+            "hashes": [
+                "sha256:0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af",
+                "sha256:9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==19.0"
+        },
         "parver": {
             "hashes": [
                 "sha256:1b37a691af145a3a193eff269d53ba5b2ab16dfbb65d47d85360755919f5fe4b",
@@ -453,19 +457,19 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:19ecf9ce9db2fce065a7a0586e07cfb4ac8614fe96edf628a264b1c70116cf8f",
-                "sha256:84d306a647cc805219916e62aab89caa97a33a1dd8c342e87a37f91073cd4746"
+                "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
+                "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.9.0"
+            "version": "==0.12.0"
         },
         "pre-commit": {
             "hashes": [
-                "sha256:2576a2776098f3902ef9540a84696e8e06bf18a337ce43a6a889e7fa5d26c4c5",
-                "sha256:82f2f2d657d7f9280de9f927ae56886d60b9ef7f3714eae92d12713cd9cb9e11"
+                "sha256:92e406d556190503630fd801958379861c94884693a032ba66629d0351fdccd4",
+                "sha256:cccc39051bc2457b0c0f7152a411f8e05e3ba2fe1a5613e4ee0833c1c1985ce3"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.15.2"
+            "version": "==1.17.0"
         },
         "py": {
             "hashes": [
@@ -499,26 +503,35 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:5ffada19f6203563680669ee7f53b64dabbeb100eb51b61996085e99c03b284a",
-                "sha256:e8218dd399a61674745138520d0d4cf2621d7e032439341bc3f647bff125818d"
+                "sha256:71e430bc85c88a430f000ac1d9b331d2407f681d6f6aec95e8bcfbc3df5b0127",
+                "sha256:881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297"
             ],
-            "version": "==2.3.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.2"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a",
+                "sha256:9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.0"
         },
         "pytest": {
             "hashes": [
-                "sha256:3f193df1cfe1d1609d4c583838bea3d532b18d6160fd3f55c9447fdca30848ec",
-                "sha256:e246cf173c01169b9617fc07264b7b1316e78d7a650055235d6d897bc80d9660"
+                "sha256:4a784f1d4f2ef198fe9b7aef793e9fa1a3b2f84e822d9b3a64a181293a572d45",
+                "sha256:926855726d8ae8371803f7b2e6ec0a69953d9c6311fa7c3b6c1b929ff92d27da"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==3.10.1"
+            "version": "==4.6.3"
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:0ab664b25c6aa9716cbf203b17ddb301932383046082c081b9848a0edf5add33",
-                "sha256:230ef817450ab0699c6cc3c9c8f7a829c34674456f2ed8df1fe1d39780f7c87f"
+                "sha256:2b097cde81a302e1047331b48cadacf23577e431b61e9c6f49a1170bbe3d3da6",
+                "sha256:e00ea4fdde970725482f1f35630d12f074e121a23801aabf2ae154ec6bdd343a"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.6.1"
+            "version": "==2.7.1"
         },
         "pytest-forked": {
             "hashes": [
@@ -536,27 +549,27 @@
         },
         "pytest-xdist": {
             "hashes": [
-                "sha256:a64915be2b23235d6cec0992b8f59b791d64083756fbf13cf574fa5757085bc7",
-                "sha256:a96ed691705882560fa3fc95531fbd4c224896c827f4004817eb2dcac4ba41a2"
+                "sha256:3489d91516d7847db5eaecff7a2e623dba68984835dbe6cedb05ae126c4fb17f",
+                "sha256:501795cb99e567746f30fe78850533d4cd500c93794128e6ab9988e92a17b1f8"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.27.0"
+            "version": "==1.29.0"
         },
         "pyyaml": {
             "hashes": [
-                "sha256:1adecc22f88d38052fb787d959f003811ca858b799590a5eaa70e63dca50308c",
-                "sha256:436bc774ecf7c103814098159fbb84c2715d25980175292c648f2da143909f95",
-                "sha256:460a5a4248763f6f37ea225d19d5c205677d8d525f6a83357ca622ed541830c2",
-                "sha256:5a22a9c84653debfbf198d02fe592c176ea548cccce47553f35f466e15cf2fd4",
-                "sha256:7a5d3f26b89d688db27822343dfa25c599627bc92093e788956372285c6298ad",
-                "sha256:9372b04a02080752d9e6f990179a4ab840227c6e2ce15b95e1278456664cf2ba",
-                "sha256:a5dcbebee834eaddf3fa7366316b880ff4062e4bcc9787b78c7fbb4a26ff2dd1",
-                "sha256:aee5bab92a176e7cd034e57f46e9df9a9862a71f8f37cad167c6fc74c65f5b4e",
-                "sha256:c51f642898c0bacd335fc119da60baae0824f2cde95b0330b56c0553439f0673",
-                "sha256:c68ea4d3ba1705da1e0d85da6684ac657912679a649e8868bd850d2c299cce13",
-                "sha256:e23d0cc5299223dcc37885dae624f382297717e459ea24053709675a976a3e19"
+                "sha256:57acc1d8533cbe51f6662a55434f0dbecfa2b9eaf115bede8f6fd00115a0c0d3",
+                "sha256:588c94b3d16b76cfed8e0be54932e5729cc185caffaa5a451e7ad2f7ed8b4043",
+                "sha256:68c8dd247f29f9a0d09375c9c6b8fdc64b60810ebf07ba4cdd64ceee3a58c7b7",
+                "sha256:70d9818f1c9cd5c48bb87804f2efc8692f1023dac7f1a1a5c61d454043c1d265",
+                "sha256:86a93cccd50f8c125286e637328ff4eef108400dd7089b46a7be3445eecfa391",
+                "sha256:a0f329125a926876f647c9fa0ef32801587a12328b4a3c741270464e3e4fa778",
+                "sha256:a3c252ab0fa1bb0d5a3f6449a4826732f3eb6c0270925548cac342bc9b22c225",
+                "sha256:b4bb4d3f5e232425e25dda21c070ce05168a786ac9eda43768ab7f3ac2770955",
+                "sha256:cd0618c5ba5bda5f4039b9398bb7fb6a317bb8298218c3de25c47c4740e4b95e",
+                "sha256:ceacb9e5f8474dcf45b940578591c7f3d960e82f926c707788a570b51ba59190",
+                "sha256:fe6a88094b64132c4bb3b631412e90032e8cfe9745a58370462240b8cb7553cd"
             ],
-            "version": "==5.1"
+            "version": "==5.1.1"
         },
         "readme-renderer": {
             "extras": [
@@ -570,11 +583,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
-                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.21.0"
+            "version": "==2.22.0"
         },
         "requests-toolbelt": {
             "hashes": [
@@ -613,7 +626,7 @@
                 "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
                 "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.12.0"
         },
         "toml": {
@@ -633,11 +646,11 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:d385c95361699e5cf7622485d9b9eae2d4864b21cd5a2374a9c381ffed701021",
-                "sha256:e22977e3ebe961f72362f6ddfb9197cc531c9737aaf5f607ef09740c849ecd05"
+                "sha256:0a860bf2683fdbb4812fe539a6c22ea3f1777843ea985cb8c3807db448a0f7ab",
+                "sha256:e288416eecd4df19d12407d0c913cbf77aa8009d7fddb18f632aded3bdbdda6b"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1'",
-            "version": "==4.31.1"
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==4.32.1"
         },
         "twine": {
             "hashes": [
@@ -674,19 +687,26 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0",
-                "sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3"
+                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
+                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3' and python_version < '4'",
-            "version": "==1.24.2"
+            "version": "==1.25.3"
         },
         "virtualenv": {
             "hashes": [
-                "sha256:15ee248d13e4001a691d9583948ad3947bcb8a289775102e4c4aa98a8b7a6d73",
-                "sha256:bfc98bb9b42a3029ee41b96dc00a34c2f254cbf7716bec824477b2c82741a5c4"
+                "sha256:99acaf1e35c7ccf9763db9ba2accbca2f4254d61d1912c5ee364f9cc4a8942a0",
+                "sha256:fe51cdbf04e5d8152af06c075404745a7419de27495a83f0d72518ad50be3ce8"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==16.5.0"
+            "version": "==16.6.0"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e",
+                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
+            ],
+            "version": "==0.1.7"
         },
         "webencodings": {
             "hashes": [
@@ -697,19 +717,19 @@
         },
         "wheel": {
             "hashes": [
-                "sha256:66a8fd76f28977bb664b098372daef2b27f60dc4d1688cfab7b37a09448f0e9d",
-                "sha256:8eb4a788b3aec8abf5ff68d4165441bc57420c9f64ca5f471f58c3969fe08668"
+                "sha256:5e79117472686ac0c4aef5bad5172ea73a1c2d1646b808c35926bd26bdfb0c08",
+                "sha256:62fcfa03d45b5b722539ccbc07b190e4bfff4bb9e3a4d470dd9f6a0981002565"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.33.1"
+            "version": "==0.33.4"
         },
         "zipp": {
             "hashes": [
-                "sha256:139391b239594fd8b91d856bc530fbd2df0892b17dd8d98a91f018715954185f",
-                "sha256:8047e4575ce8d700370a3301bbfc972896a5845eb62dd535da395b86be95dfad"
+                "sha256:8c1019c6aad13642199fbe458275ad6a84907634cc9f0989877ccc4a2840139d",
+                "sha256:ca943a7e809cc12257001ccfb99e3563da9af99d52f261725e96dfe0f9275bc3"
             ],
             "markers": "python_version >= '2.7'",
-            "version": "==0.4.0"
+            "version": "==0.5.1"
         }
     },
     "develop": {
@@ -722,11 +742,11 @@
         },
         "babel": {
             "hashes": [
-                "sha256:6778d85147d5d85345c14a26aada5e478ab04e39b078b0745ee6870c2b5cf669",
-                "sha256:8cba50f48c529ca3fa18cf81fa9403be176d374ac4d60738b839122dfaaa3d23"
+                "sha256:af92e6106cb7c55286b25b38ad7695f8b4efb36a90ba483d7f7a6628c46158ab",
+                "sha256:e86135ae101e31e2c8ec20a4e0c5220f4eed12487d5cf3f78be7e98d3a57fc28"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.6.0"
+            "version": "==2.7.0"
         },
         "certifi": {
             "hashes": [
@@ -826,17 +846,18 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:5ffada19f6203563680669ee7f53b64dabbeb100eb51b61996085e99c03b284a",
-                "sha256:e8218dd399a61674745138520d0d4cf2621d7e032439341bc3f647bff125818d"
+                "sha256:71e430bc85c88a430f000ac1d9b331d2407f681d6f6aec95e8bcfbc3df5b0127",
+                "sha256:881c4c157e45f30af185c1ffe8d549d48ac9127433f2c380c24b84572ad66297"
             ],
-            "version": "==2.3.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.2"
         },
         "pyparsing": {
             "hashes": [
                 "sha256:1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a",
                 "sha256:9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.0"
         },
         "pytz": {
@@ -848,18 +869,18 @@
         },
         "requests": {
             "hashes": [
-                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
-                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.21.0"
+            "version": "==2.22.0"
         },
         "six": {
             "hashes": [
                 "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
                 "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.12.0"
         },
         "snowballstemmer": {
@@ -943,11 +964,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0",
-                "sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3"
+                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
+                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3' and python_version < '4'",
-            "version": "==1.24.2"
+            "version": "==1.25.3"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -27,6 +27,7 @@
                 "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92",
                 "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
             ],
+            "markers": "python_version <= '2.7'",
             "version": "==1.4.3"
         },
         "arpeggio": {
@@ -59,6 +60,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==19.1.0"
         },
+        "backports.functools-lru-cache": {
+            "hashes": [
+                "sha256:9d98697f088eb1b0fa451391f91afb5e3ebde16bbdb272819fd091151fda4f1a",
+                "sha256:f0b0e4eba956de51238e17573b7087e852dfe9854afd2e9c873f73fc0ca0a6dd"
+            ],
+            "markers": "python_version < '3.2'",
+            "version": "==1.5"
+        },
         "black": {
             "hashes": [
                 "sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf",
@@ -77,10 +86,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
-                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
+                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
+                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
             ],
-            "version": "==2019.3.9"
+            "version": "==2019.6.16"
         },
         "cffi": {
             "hashes": [
@@ -181,10 +190,19 @@
         },
         "configparser": {
             "hashes": [
-                "sha256:5308b47021bc2340965c371f0f058cc6971a04502638d4244225c49d80db273a"
+                "sha256:8be81d89d6e7b4c0d4e44bcc525845f6da25821de80cb5e06e7e0238a2899e32",
+                "sha256:da60d0014fd8c55eb48c1c5354352e363e2d30bbf7057e5e171a468390184c75"
             ],
-            "markers": "python_version < '3.2'",
-            "version": "==3.5.0"
+            "markers": "python_version == '2.7'",
+            "version": "==3.7.4"
+        },
+        "contextlib2": {
+            "hashes": [
+                "sha256:509f9419ee91cdd00ba34443217d5ca51f5a364a404e1dce9e8979cea969ca48",
+                "sha256:f5260a6e679d2ff42ec91ec5252f4eeffdcf21053db9113bd0a8e4d953769c00"
+            ],
+            "markers": "python_version < '3'",
+            "version": "==0.5.5"
         },
         "coverage": {
             "hashes": [
@@ -243,6 +261,16 @@
             "markers": "python_version >= '2.7'",
             "version": "==0.3"
         },
+        "enum34": {
+            "hashes": [
+                "sha256:2d81cbbe0e73112bdfe6ef8576f2238f2ba27dd0d55752a776c41d38b7da2850",
+                "sha256:644837f692e5f550741432dd3f223bbb9852018674981b1664e5dc339387588a",
+                "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
+                "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1"
+            ],
+            "markers": "python_version < '3.4'",
+            "version": "==1.1.6"
+        },
         "execnet": {
             "hashes": [
                 "sha256:027ee5d961afa01e97b90d6ccc34b4ed976702bc58e7f092b3c513ea288cb6d2",
@@ -275,6 +303,22 @@
             "markers": "python_version < '3.0'",
             "version": "==1.0.2"
         },
+        "functools32": {
+            "hashes": [
+                "sha256:89d824aa6c358c421a234d7f9ee0bd75933a67c29588ce50aaa3acdf4d403fa0",
+                "sha256:f6253dfbe0538ad2e387bd8fdfd9293c925d63553f5813c4e587745416501e6d"
+            ],
+            "markers": "python_version < '3.2'",
+            "version": "==3.2.3.post2"
+        },
+        "futures": {
+            "hashes": [
+                "sha256:9ec02aa7d674acb8618afb127e27fde7fc68994c0437ad759fa094a574adb265",
+                "sha256:ec0a6cb848cc212002b9828c3e34c675e0c9ff6741dc445cab6fdd4e1085d1f1"
+            ],
+            "markers": "python_version < '3.2'",
+            "version": "==3.2.0"
+        },
         "identify": {
             "hashes": [
                 "sha256:0a11379b46d06529795442742a043dc2fa14cd8c995ae81d1febbc5f1c014c87",
@@ -304,6 +348,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.18"
+        },
+        "importlib-resources": {
+            "hashes": [
+                "sha256:6e2783b2538bd5a14678284a3962b0660c715e5a0f10243fd5e00a4b5974f50b",
+                "sha256:d3279fd0f6f847cced9f7acc19bd3e5df54d34f93a2e7bb5f238f81545787078"
+            ],
+            "markers": "python_version < '3.7'",
+            "version": "==1.0.2"
         },
         "incremental": {
             "hashes": [
@@ -378,13 +430,16 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
+                "sha256:c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc",
                 "sha256:c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e",
-                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d"
+                "sha256:fe7a7cae1ccb57d33952113ff4fa1bc5f879963600ed74918f1236e212ee50b9",
+                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d",
+                "sha256:38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4",
+                "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092"
             ],
-            "version": "==4.3.0"
+            "version": "==5.0.0"
         },
-        "mypy": {
+		"mypy": {
             "hashes": [
                 "sha256:2afe51527b1f6cdc4a5f34fc90473109b22bf7f21086ba3e9451857cf11489e6",
                 "sha256:56a16df3e0abb145d8accd5dbb70eba6c4bd26e2f89042b491faa78c9635d1e2",
@@ -434,11 +489,11 @@
         },
         "pathlib2": {
             "hashes": [
-                "sha256:8eb170f8d0d61825e09a95b38be068299ddeda82f35e96c3301a8a5e7604cb83",
-                "sha256:d1aa2a11ba7b8f7b21ab852b1fb5afb277e1bb99d5dfc663380b5015c0d80c5a"
+                "sha256:25199318e8cc3c25dcb45cbe084cc061051336d5a9ea2a12448d3d8cb748f742",
+                "sha256:5887121d7f7df3603bca2f710e7219f3eca0eb69e0b7cc6e0a022e155ac931a7"
             ],
-            "markers": "python_version < '3.6'",
-            "version": "==2.3.2"
+            "markers": "python_version < '3'",
+            "version": "==2.3.3"
         },
         "pip-shims": {
             "editable": true,
@@ -606,20 +661,20 @@
         },
         "scandir": {
             "hashes": [
-                "sha256:04b8adb105f2ed313a7c2ef0f1cf7aff4871aa7a1883fa4d8c44b5551ab052d6",
-                "sha256:1444134990356c81d12f30e4b311379acfbbcd03e0bab591de2696a3b126d58e",
-                "sha256:1b5c314e39f596875e5a95dd81af03730b338c277c54a454226978d5ba95dbb6",
-                "sha256:346619f72eb0ddc4cf355ceffd225fa52506c92a2ff05318cfabd02a144e7c4e",
-                "sha256:44975e209c4827fc18a3486f257154d34ec6eaec0f90fef0cca1caa482db7064",
-                "sha256:61859fd7e40b8c71e609c202db5b0c1dbec0d5c7f1449dec2245575bdc866792",
-                "sha256:a5e232a0bf188362fa00123cc0bb842d363a292de7126126df5527b6a369586a",
-                "sha256:c14701409f311e7a9b7ec8e337f0815baf7ac95776cc78b419a1e6d49889a383",
-                "sha256:c7708f29d843fc2764310732e41f0ce27feadde453261859ec0fca7865dfc41b",
-                "sha256:c9009c527929f6e25604aec39b0a43c3f831d2947d89d6caaab22f057b7055c8",
-                "sha256:f5c71e29b4e2af7ccdc03a020c626ede51da471173b4a6ad1e904f2b2e04b4bd"
+                "sha256:2586c94e907d99617887daed6c1d102b5ca28f1085f90446554abf1faf73123e",
+                "sha256:2ae41f43797ca0c11591c0c35f2f5875fa99f8797cb1a1fd440497ec0ae4b022",
+                "sha256:2b8e3888b11abb2217a32af0766bc06b65cc4a928d8727828ee68af5a967fa6f",
+                "sha256:2c712840c2e2ee8dfaf36034080108d30060d759c7b73a01a52251cc8989f11f",
+                "sha256:4d4631f6062e658e9007ab3149a9b914f3548cb38bfb021c64f39a025ce578ae",
+                "sha256:67f15b6f83e6507fdc6fca22fedf6ef8b334b399ca27c6b568cbfaa82a364173",
+                "sha256:7d2d7a06a252764061a020407b997dd036f7bd6a175a5ba2b345f0a357f0b3f4",
+                "sha256:8c5922863e44ffc00c5c693190648daa6d15e7c1207ed02d6f46a8dcc2869d32",
+                "sha256:92c85ac42f41ffdc35b6da57ed991575bdbe69db895507af88b9f499b701c188",
+                "sha256:b24086f2375c4a094a6b51e78b4cf7ca16c721dcee2eddd7aa6494b42d6d519d",
+                "sha256:cb925555f43060a1745d0a321cca94bcea927c50114b623d73179189a4e100ac"
             ],
             "markers": "python_version < '3.5'",
-            "version": "==1.9.0"
+            "version": "==1.10.0"
         },
         "six": {
             "hashes": [
@@ -685,6 +740,15 @@
             "markers": "python_version >= '3.5'",
             "version": "==1.3.5"
         },
+        "typing": {
+            "hashes": [
+                "sha256:4027c5f6127a6267a435201981ba156de91ad0d1d98e9ddc2aa173453453492d",
+                "sha256:57dcf675a99b74d64dacf6fba08fb17cf7e3d5fdff53d4a30ea2a5e7e52543d4",
+                "sha256:a4c8473ce11a65999c8f59cb093e70686b6c84c98df58c1dae9b3b196089858a"
+            ],
+            "markers": "python_version < '3.5'",
+            "version": "==3.6.6"
+        },
         "urllib3": {
             "hashes": [
                 "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
@@ -695,11 +759,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:99acaf1e35c7ccf9763db9ba2accbca2f4254d61d1912c5ee364f9cc4a8942a0",
-                "sha256:fe51cdbf04e5d8152af06c075404745a7419de27495a83f0d72518ad50be3ce8"
+                "sha256:b7335cddd9260a3dd214b73a2521ffc09647bde3e9457fcca31dc3be3999d04a",
+                "sha256:d28ca64c0f3f125f59cabf13e0a150e1c68e5eea60983cc4395d88c584495783"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==16.6.0"
+            "version": "==16.6.1"
         },
         "wcwidth": {
             "hashes": [
@@ -750,10 +814,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
-                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
+                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
+                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
             ],
-            "version": "==2019.3.9"
+            "version": "==2019.6.16"
         },
         "chardet": {
             "hashes": [
@@ -892,11 +956,11 @@
         },
         "sphinx": {
             "hashes": [
-                "sha256:652eb8c566f18823a022bb4b6dbc868d366df332a11a0226b5bc3a798a479f17",
-                "sha256:d222626d8356de702431e813a05c68a35967e3d66c6cd1c2c89539bb179a7464"
+                "sha256:9f3e17c64b34afc653d7c5ec95766e03043cc6d80b0de224f59b6b6e19d37c3c",
+                "sha256:c7658aab75c920288a8cf6f09f244c6cfdae30d82d803ac1634d9f223a80ca08"
             ],
             "index": "pypi",
-            "version": "==1.8.1"
+            "version": "==1.8.5"
         },
         "sphinx-rtd-theme": {
             "hashes": [
@@ -956,11 +1020,20 @@
         },
         "sphinxcontrib-websupport": {
             "hashes": [
-                "sha256:68ca7ff70785cbe1e7bccc71a48b5b6d965d79ca50629606c7861a21b206d9dd",
-                "sha256:9de47f375baf1ea07cdb3436ff39d7a9c76042c10a769c52353ec46e4e8fc3b9"
+                "sha256:1501befb0fdf1d1c29a800fdbf4ef5dc5369377300ddbdd16d2cd40e54c6eefc",
+                "sha256:e02f717baf02d0b6c3dd62cf81232ffca4c9d5c331e03766982e3ff9f1d2bc3f"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.1.2"
+        },
+        "typing": {
+            "hashes": [
+                "sha256:4027c5f6127a6267a435201981ba156de91ad0d1d98e9ddc2aa173453453492d",
+                "sha256:57dcf675a99b74d64dacf6fba08fb17cf7e3d5fdff53d4a30ea2a5e7e52543d4",
+                "sha256:a4c8473ce11a65999c8f59cb093e70686b6c84c98df58c1dae9b3b196089858a"
             ],
             "markers": "python_version < '3.5'",
-            "version": "==1.1.0"
+            "version": "==3.6.6"
         },
         "urllib3": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -492,7 +492,7 @@
                 "sha256:25199318e8cc3c25dcb45cbe084cc061051336d5a9ea2a12448d3d8cb748f742",
                 "sha256:5887121d7f7df3603bca2f710e7219f3eca0eb69e0b7cc6e0a022e155ac931a7"
             ],
-            "markers": "python_version < '3'",
+            "markers": "python_version < '3.6'",
             "version": "==2.3.3"
         },
         "pip-shims": {

--- a/README.rst
+++ b/README.rst
@@ -118,6 +118,7 @@ utils.misc         is_installable_dir          utils
 index              Link
 operations.prepare make_abstract_dist          req.req_set
 cli.cmdoptions     make_option_group           cmdoptions
+index              CandidateEvaluator
 index              PackageFinder
 req.req_file       parse_requirements
 index              parse_version
@@ -141,7 +142,7 @@ download           SafeFileCache
 download           url_to_path
 download           unpack_url
 locations          USER_CACHE_DIR
-vcs                VcsSupport
+vcs.versioncontrol VcsSupport                  vcs.VcsSupport
 wheel              Wheel
 wheel              WheelBuilder
 cache              WheelCache                  wheel

--- a/README.rst
+++ b/README.rst
@@ -94,56 +94,61 @@ Available Shims
 
 **pip-shims** provides the following compatibility shims:
 
-================== =========================== ===================================
-Import Path        Import Name                 Former Path
-================== =========================== ===================================
-req.constructors   _strip_extras               req.req_install
-cli                cmdoptions                  cmdoptions
-cli.base_command   Command                     basecommand
-cli.parser         ConfigOptionParser          baseparser
-commands.freeze    DEV_PKGS
-exceptions         DistributionNotFound
-utils.hashes       FAVORITE_HASH
-models             FormatControl               index
-utils.misc         get_installed_distributions utils
-utils.compat       stdlib_pkgs                 compat
-cli.cmdoptions     index_group                 cmdoptions
-req.req_install    InstallRequirement
-req.constructors   install_req_from_line       req.req_install.InstallRequirement
-req.constructors   install_req_from_editable   req.req_install.InstallRequirement
-req.req_uninstall  UninstallPathSet
-download           is_archive_file
-download           is_file_url
-utils.misc         is_installable_dir          utils
-index              Link
-operations.prepare make_abstract_dist          req.req_set
-cli.cmdoptions     make_option_group           cmdoptions
-index              CandidateEvaluator
-index              PackageFinder
-req.req_file       parse_requirements
-index              parse_version
-download           path_to_url
-__version__        pip_version
-exceptions         PipError
-exceptions         InstallationError
-exceptions         UninstallationError
-exceptions         DistributionNotFound
-exceptions         RequirementsFileParseError
-exceptions         BestVersionAlreadyInstalled
-exceptions         BadCommand
-exceptions         CommandError
-exceptions         PreviousBuildDirError
-operations.prepare RequirementPreparer
-operations.freeze  FrozenRequirement           <`__init__`>
-req.req_set        RequirementSet
-req.req_tracker    RequirementTracker
-resolve            Resolver
-download           SafeFileCache
-download           url_to_path
-download           unpack_url
-locations          USER_CACHE_DIR
-vcs.versioncontrol VcsSupport                  vcs.VcsSupport
-wheel              Wheel
-wheel              WheelBuilder
-cache              WheelCache                  wheel
-================== =========================== ===================================
+======================== ========================================== =======================================
+Import Path               Import Name                                Former Path
+======================== ========================================== =======================================
+req.constructors          _strip_extras                              req.req_install
+cli                       cmdoptions                                 cmdoptions
+cli.base_command          Command                                    basecommand
+cli.parser                ConfigOptionParser                         baseparser
+commands.freeze           DEV_PKGS
+exceptions                DistributionNotFound
+utils.hashes              FAVORITE_HASH
+models                    FormatControl                              index
+utils.misc                get_installed_distributions                utils
+utils.compat              stdlib_pkgs                                compat
+cli.cmdoptions            index_group                                cmdoptions
+req.req_install           InstallRequirement
+req.constructors          install_req_from_line                      req.req_install.InstallRequirement
+req.constructors          install_req_from_editable                  req.req_install.InstallRequirement
+req.req_uninstall         UninstallPathSet
+distributions             make_distribution_for_install_requirement  operations.prepare.make_abstract_dist
+distributions.base        AbstractDistribution
+distributions.source      SourceDistribution
+distributions.installed   InstalledDistribution
+distributions.wheel       WheelDistribution
+download                  is_archive_file
+download                  is_file_url
+utils.misc                is_installable_dir                         utils
+index                     Link
+operations.prepare        make_abstract_dist                         req.req_set
+cli.cmdoptions            make_option_group                          cmdoptions
+index                     CandidateEvaluator
+index                     PackageFinder
+req.req_file              parse_requirements
+index                     parse_version
+download                  path_to_url
+__version__               pip_version
+exceptions                PipError
+exceptions                InstallationError
+exceptions                UninstallationError
+exceptions                DistributionNotFound
+exceptions                RequirementsFileParseError
+exceptions                BestVersionAlreadyInstalled
+exceptions                BadCommand
+exceptions                CommandError
+exceptions                PreviousBuildDirError
+operations.prepare        RequirementPreparer
+operations.freeze         FrozenRequirement                          <`__init__`>
+req.req_set               RequirementSet
+req.req_tracker           RequirementTracker
+resolve                   Resolver
+download                  SafeFileCache
+download                  url_to_path
+download                  unpack_url
+locations                 USER_CACHE_DIR
+vcs.versioncontrol        VcsSupport                                 vcs.VcsSupport
+wheel                     Wheel
+wheel                     WheelBuilder
+cache                     WheelCache                                 wheel
+======================== ========================================== =======================================

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -97,56 +97,61 @@ models             FormatControl               index
 req.constructors   install_req_from_line       req.req_install.InstallRequirement
 req.constructors   install_req_from_editable   req.req_install.InstallRequirement
 
-================== =========================== ===================================
-Import Path        Import Name                 Former Path
-================== =========================== ===================================
-req.constructors   _strip_extras               req.req_install
-cli                cmdoptions                  cmdoptions
-cli.base_command   Command                     basecommand
-cli.parser         ConfigOptionParser          baseparser
-commands.freeze    DEV_PKGS
-exceptions         DistributionNotFound
-utils.hashes       FAVORITE_HASH
-models             FormatControl               index
-utils.misc         get_installed_distributions utils
-utils.compat       stdlib_pkgs                 compat
-cli.cmdoptions     index_group                 cmdoptions
-req.req_install    InstallRequirement
-req.constructors   install_req_from_line       req.req_install.InstallRequirement
-req.constructors   install_req_from_editable   req.req_install.InstallRequirement
-req.req_uninstall  UninstallPathSet
-download           is_archive_file
-download           is_file_url
-utils.misc         is_installable_dir          utils
-index              Link
-operations.prepare make_abstract_dist          req.req_set
-cli.cmdoptions     make_option_group           cmdoptions
-index              CandidateEvaluator
-index              PackageFinder
-req.req_file       parse_requirements
-index              parse_version
-download           path_to_url
-__version__        pip_version
-exceptions         PipError
-exceptions         InstallationError
-exceptions         UninstallationError
-exceptions         DistributionNotFound
-exceptions         RequirementsFileParseError
-exceptions         BestVersionAlreadyInstalled
-exceptions         BadCommand
-exceptions         CommandError
-exceptions         PreviousBuildDirError
-operations.prepare RequirementPreparer
-operations.freeze  FrozenRequirement           <`__init__`>
-req.req_set        RequirementSet
-req.req_tracker    RequirementTracker
-resolve            Resolver
-download           SafeFileCache
-download           url_to_path
-download           unpack_url
-locations          USER_CACHE_DIR
-vcs.versioncontrol VcsSupport                  vcs.VcsSupport
-wheel              Wheel
-wheel              WheelBuilder
-cache              WheelCache                  wheel
-================== =========================== ===================================
+======================== ========================================== =======================================
+Import Path               Import Name                                Former Path
+======================== ========================================== =======================================
+req.constructors          _strip_extras                              req.req_install
+cli                       cmdoptions                                 cmdoptions
+cli.base_command          Command                                    basecommand
+cli.parser                ConfigOptionParser                         baseparser
+commands.freeze           DEV_PKGS
+exceptions                DistributionNotFound
+utils.hashes              FAVORITE_HASH
+models                    FormatControl                              index
+utils.misc                get_installed_distributions                utils
+utils.compat              stdlib_pkgs                                compat
+cli.cmdoptions            index_group                                cmdoptions
+req.req_install           InstallRequirement
+req.constructors          install_req_from_line                      req.req_install.InstallRequirement
+req.constructors          install_req_from_editable                  req.req_install.InstallRequirement
+req.req_uninstall         UninstallPathSet
+distributions             make_distribution_for_install_requirement  operations.prepare.make_abstract_dist
+distributions.base        AbstractDistribution
+distributions.source      SourceDistribution
+distributions.installed   InstalledDistribution
+distributions.wheel       WheelDistribution
+download                  is_archive_file
+download                  is_file_url
+utils.misc                is_installable_dir                         utils
+index                     Link
+operations.prepare        make_abstract_dist                         req.req_set
+cli.cmdoptions            make_option_group                          cmdoptions
+index                     CandidateEvaluator
+index                     PackageFinder
+req.req_file              parse_requirements
+index                     parse_version
+download                  path_to_url
+__version__               pip_version
+exceptions                PipError
+exceptions                InstallationError
+exceptions                UninstallationError
+exceptions                DistributionNotFound
+exceptions                RequirementsFileParseError
+exceptions                BestVersionAlreadyInstalled
+exceptions                BadCommand
+exceptions                CommandError
+exceptions                PreviousBuildDirError
+operations.prepare        RequirementPreparer
+operations.freeze         FrozenRequirement                          <`__init__`>
+req.req_set               RequirementSet
+req.req_tracker           RequirementTracker
+resolve                   Resolver
+download                  SafeFileCache
+download                  url_to_path
+download                  unpack_url
+locations                 USER_CACHE_DIR
+vcs.versioncontrol        VcsSupport                                 vcs.VcsSupport
+wheel                     Wheel
+wheel                     WheelBuilder
+cache                     WheelCache                                 wheel
+======================== ========================================== =======================================

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -121,6 +121,7 @@ utils.misc         is_installable_dir          utils
 index              Link
 operations.prepare make_abstract_dist          req.req_set
 cli.cmdoptions     make_option_group           cmdoptions
+index              CandidateEvaluator
 index              PackageFinder
 req.req_file       parse_requirements
 index              parse_version
@@ -144,7 +145,7 @@ download           SafeFileCache
 download           url_to_path
 download           unpack_url
 locations          USER_CACHE_DIR
-vcs                VcsSupport
+vcs.versioncontrol VcsSupport                  vcs.VcsSupport
 wheel              Wheel
 wheel              WheelBuilder
 cache              WheelCache                  wheel

--- a/news/27.feature.rst
+++ b/news/27.feature.rst
@@ -1,0 +1,1 @@
+Updated ``PackageFinder`` test and added ``CandidateEvaluator`` import starting with ``pip>=19.1`` for finding prerelease candidates.

--- a/news/28.bugfix.rst
+++ b/news/28.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed import paths for ``VcsSupport`` on ``pip>19.1.1``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,8 +46,8 @@ install_requires =
 [options.extras_require]
 tests =
     pytest-timeout
-    pytest>=3.6.0,<4.0
-    pytest-xdist<1.28
+    pytest
+    pytest-xdist
     pytest-cov
     twine
     readme-renderer[md]

--- a/src/pip_shims/shims.py
+++ b/src/pip_shims/shims.py
@@ -199,7 +199,8 @@ class _shims(object):
                 "9999",
             ),
             "SourceDistribution": (
-                ("operations.prepare.IsSDist", "7.0.0", "19.1.1"),
+                ("req.req_set.IsSDist", "7.0.0", "9.0.3"),
+                ("operations.prepare.IsSDist", "10.0.0", "19.1.1"),
                 ("distributions.source.SourceDistribution", "19.1.2", "9999"),
             ),
             "WheelDistribution": (

--- a/src/pip_shims/shims.py
+++ b/src/pip_shims/shims.py
@@ -141,8 +141,18 @@ class _shims(object):
             ),
             "Link": ("index.Link", "7.0.0", "9999"),
             "make_abstract_dist": (
-                ("operations.prepare.make_abstract_dist", "10.0.0", "9999"),
+                (
+                    "distributions.make_distribution_for_install_requirement",
+                    "19.1.2",
+                    "9999",
+                ),
+                ("operations.prepare.make_abstract_dist", "10.0.0", "19.1.1"),
                 ("req.req_set.make_abstract_dist", "7.0.0", "9.0.3"),
+            ),
+            "make_distribution_for_install_requirement": (
+                "distributions.make_distribution_for_install_requirement",
+                "19.1.2",
+                "9999",
             ),
             "make_option_group": (
                 ("cli.cmdoptions.make_option_group", "18.1", "9999"),
@@ -175,6 +185,26 @@ class _shims(object):
                 ("wheel.WheelCache", "7", "9.0.3"),
             ),
             "WheelBuilder": ("wheel.WheelBuilder", "7.0.0", "9999"),
+            "AbstractDistribution": (
+                "distributions.base.AbstractDistribution",
+                "19.1.2",
+                "9999",
+            ),
+            "InstalledDistribution": (
+                "distributions.installed.InstalledDistribution",
+                "19.1.2",
+                "9999",
+            ),
+            "SourceDistribution": (
+                "distributions.source.SourceDistribution",
+                "19.1.2",
+                "9999",
+            ),
+            "WheelDistribution": (
+                "distributions.wheel.WheelDistribution",
+                "19.1.2",
+                "9999",
+            ),
             "PyPI": ("models.index.PyPI", "7.0.0", "9999"),
             "stdlib_pkgs": (
                 ("utils.compat.stdlib_pkgs", "18.1", "9999"),

--- a/src/pip_shims/shims.py
+++ b/src/pip_shims/shims.py
@@ -149,6 +149,7 @@ class _shims(object):
                 ("cmdoptions.make_option_group", "7.0.0", "18.0"),
             ),
             "PackageFinder": ("index.PackageFinder", "7.0.0", "9999"),
+            "CandidateEvaluator": ("index.CandidateEvaluator", "19.1", "9999"),
             "parse_requirements": ("req.req_file.parse_requirements", "7.0.0", "9999"),
             "path_to_url": ("download.path_to_url", "7.0.0", "9999"),
             "PipError": ("exceptions.PipError", "7.0.0", "9999"),
@@ -164,7 +165,10 @@ class _shims(object):
             "UninstallPathSet": ("req.req_uninstall.UninstallPathSet", "7.0.0", "9999"),
             "url_to_path": ("download.url_to_path", "7.0.0", "9999"),
             "USER_CACHE_DIR": ("locations.USER_CACHE_DIR", "7.0.0", "9999"),
-            "VcsSupport": ("vcs.VcsSupport", "7.0.0", "9999"),
+            "VcsSupport": (
+                ("vcs.VcsSupport", "7.0.0", "19.1.1"),
+                ("vcs.versioncontrol.VcsSupport", "19.2", "9999"),
+            ),
             "Wheel": ("wheel.Wheel", "7.0.0", "9999"),
             "WheelCache": (
                 ("cache.WheelCache", "10.0.0", "9999"),

--- a/src/pip_shims/shims.py
+++ b/src/pip_shims/shims.py
@@ -196,9 +196,8 @@ class _shims(object):
                 "9999",
             ),
             "SourceDistribution": (
-                "distributions.source.SourceDistribution",
-                "19.1.2",
-                "9999",
+                ("operations.prepare.IsSDist", "7.0.0", "19.1.1"),
+                ("distributions.source.SourceDistribution", "19.1.2", "9999"),
             ),
             "WheelDistribution": (
                 "distributions.wheel.WheelDistribution",

--- a/src/pip_shims/shims.py
+++ b/src/pip_shims/shims.py
@@ -170,7 +170,10 @@ class _shims(object):
             ),
             "RequirementSet": ("req.req_set.RequirementSet", "7.0.0", "9999"),
             "RequirementTracker": ("req.req_tracker.RequirementTracker", "7.0.0", "9999"),
-            "Resolver": ("resolve.Resolver", "7.0.0", "9999"),
+            "Resolver": (
+                ("resolve.Resolver", "7.0.0", "19.1.1"),
+                ("legacy_resolve.Resolver", "19.1.2", "9999"),
+            ),
             "SafeFileCache": ("download.SafeFileCache", "7.0.0", "9999"),
             "UninstallPathSet": ("req.req_uninstall.UninstallPathSet", "7.0.0", "9999"),
             "url_to_path": ("download.url_to_path", "7.0.0", "9999"),

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -83,18 +83,26 @@ def _render_log():
 REL_TYPES = ("major", "minor", "patch")
 
 
-def _bump_release(version, type_):
+def _bump_release(version, type_, log=False):
     if type_ not in REL_TYPES:
         raise ValueError(f"{type_} not in {REL_TYPES}")
     index = REL_TYPES.index(type_)
-    next_version = version.base_version().bump_release(index=index)
-    print(f"[bump] {version} -> {next_version}")
+    current_version = version.base_version()
+    if version.is_prerelease and type_ == "patch":
+        next_version = current_version
+    else:
+        next_version = current_version.bump_release(index=index)
+    if log:
+        print(f"[bump] {version} -> {next_version}")
+    print(f"{next_version}")
     return next_version
 
 
-def _prebump(version, prebump):
+def _prebump(version, prebump, log=False):
     next_version = version.bump_release(index=prebump).bump_dev()
-    print(f"[bump] {version} -> {next_version}")
+    if log:
+        print(f"[bump] {version} -> {next_version}")
+    print(f"{next_version}")
     return next_version
 
 
@@ -102,58 +110,79 @@ PREBUMP = "patch"
 
 
 @invoke.task(pre=[clean])
-def build(ctx, draft=True, yes=False):
-    towncrier_cmd = "towncrier"
-    if not draft and yes:
-        towncrier_cmd = f"{towncrier_cmd} --yes"
-    elif draft:
-        towncrier_cmd = f"{towncrier_cmd} --draft"
+def build(ctx):
     ctx.run("python setup.py sdist bdist_wheel")
 
 
-@invoke.task(pre=[build])
-def publish(ctx, repo, config_file=None, yes=False):
-    dist_pattern = f'{PACKAGE_NAME.replace("-", "[-_]")}-*'
-    artifacts = list(ROOT.joinpath("dist").glob(dist_pattern))
-    filename_display = "\n".join(f"  {a}" for a in artifacts)
-    print(f"[release] Will upload:\n{filename_display}")
-    if not yes:
-        try:
-            input("[release] Release ready. ENTER to upload, CTRL-C to abort: ")
-        except KeyboardInterrupt:
-            print("\nAborted!")
-            return
+@invoke.task()
+def get_next_version(ctx, type_="patch", log=False):
+    version = _read_version()
+    if type_ in ("dev", "pre"):
+        idx = REL_TYPES.index("patch")
+        new_version = _prebump(version, idx, log=log)
+    else:
+        new_version = _bump_release(version, type_, log=log)
+    return new_version
 
-    arg_display = " ".join(f'"{n}"' for n in artifacts)
-    cmd = f'twine upload --repository="{repo}"'
-    if config_file:
-        cmd = f'{cmd} --config-file="{config_file}"'
-    cmd = f"{cmd} {arg_display}"
-    ctx.run(cmd)
+
+@invoke.task()
+def bump_version(ctx, type_="patch", log=False, dry_run=False):
+    new_version = get_next_version(ctx, type_, log=log)
+    if not dry_run:
+        _write_version(new_version)
+    return new_version
+
+
+@invoke.task()
+def generate_news(ctx, yes=False, dry_run=False):
+    command = "towncrier"
+    if dry_run:
+        command = f"{command} --draft"
+    elif yes:
+        command = f"{command} --yes"
+    ctx.run(command)
+
+
+@invoke.task()
+def get_changelog(ctx):
+    changelog = _render_log()
+    print(changelog)
+    return changelog
+
+
+@invoke.task(optional=["version", "type_"])
+def tag_release(ctx, version=None, type_="patch", yes=False, dry_run=False):
+    if version is None:
+        version = bump_version(ctx, type_, log=not dry_run, dry_run=dry_run)
+    else:
+        _write_version(version)
+    tag_content = get_changelog(ctx)
+    generate_news(ctx, yes=yes, dry_run=dry_run)
+    git_commit_cmd = f'git commit -am "Release {version}"'
+    tag_content = tag_content.replace('"', '\\"')
+    git_tag_cmd = f'git tag -a {version} -m "Version {version}\n\n{tag_content}"'
+    if dry_run:
+        print("Would run commands:")
+        print(f"    {git_commit_cmd}")
+        print(f"    {git_tag_cmd}")
+    else:
+        ctx.run(git_commit_cmd)
+        ctx.run(git_tag_cmd)
 
 
 @invoke.task(pre=[clean])
-def release(ctx, type_, repo, prebump=PREBUMP, config_file=None, commit=True, yes=False):
+def release(ctx, type_, repo, prebump=PREBUMP, yes=False):
     """Make a new release.
     """
     if prebump not in REL_TYPES:
         raise ValueError(f"{type_} not in {REL_TYPES}")
     prebump = REL_TYPES.index(prebump)
 
-    version = _read_version()
-    version = _bump_release(version, type_)
-    _write_version(version)
+    version = bump_version(ctx, type_, log=True)
 
     # Needs to happen before Towncrier deletes fragment files.
-    tag_content = _render_log()
 
-    ctx.run("towncrier")
-
-    if commit:
-        ctx.run(f'git commit -am "Release {version}"')
-
-        tag_content = tag_content.replace('"', '\\"')
-        ctx.run(f'git tag -a {version} -m "Version {version}\n\n{tag_content}"')
+    tag_release(version, yes=yes)
 
     ctx.run(f"python setup.py sdist bdist_wheel")
 
@@ -169,16 +198,12 @@ def release(ctx, type_, repo, prebump=PREBUMP, config_file=None, commit=True, ye
             return
 
     arg_display = " ".join(f'"{n}"' for n in artifacts)
-    cmd = f'twine upload --repository="{repo}"'
-    if config_file:
-        cmd = f'{cmd} --config-file="{config_file}"'
-    cmd = f"{cmd} {arg_display}"
-    ctx.run(cmd)
+    ctx.run(f'twine upload --repository="{repo}" {arg_display}')
 
     version = _prebump(version, prebump)
     _write_version(version)
-    if commit:
-        ctx.run(f'git commit -am "Prebump to {version}"')
+
+    ctx.run(f'git commit -am "Prebump to {version}"')
 
 
 @invoke.task

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -195,13 +195,22 @@ def test_resolution(tmpdir, PipCommand):
     pip_options.cache_dir = CACHE_DIR.strpath
     session = pip_command._build_session(pip_options)
     assert session
-    finder = PackageFinder(
-        find_links=pip_options.find_links,
-        index_urls=[pip_options.index_url],
-        trusted_hosts=pip_options.trusted_hosts,
-        allow_all_prereleases=False,
-        session=session,
-    )
+    finder_args = {
+        "find_links": pip_options.find_links,
+        "index_urls": [pip_options.index_url],
+        "trusted_hosts": pip_options.trusted_hosts,
+        "session": session,
+    }
+    if parse_version(pip_version) > parse_version("19.1.1"):
+        finder_args["candidate_evaluator"] = CandidateEvaluator(
+            target_python=None,
+            prefer_binary=False,
+            allow_all_prereleases=False,
+            ignore_requires_python=False,
+        )
+    else:
+        finder_args["allow_all_prereleases"] = False
+    finder = PackageFinder(**finder_args)
     ireq = InstallRequirement.from_line("requests>=2.18")
     if install_req_from_line:
         ireq2 = install_req_from_line("requests>=2.18")

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -33,6 +33,7 @@ from pip_shims import (
     RequirementTracker,
     Resolver,
     SafeFileCache,
+    SourceDistribution,
     UninstallationError,
     VcsSupport,
     Wheel,
@@ -306,7 +307,7 @@ def test_abstract_dist():
         "git+https://github.com/requests/requests.git@2.19.1#egg=requests"
     )
     abs_dist = make_abstract_dist(ireq)
-    assert abs_dist.__class__.__name__ == "IsSDist"
+    assert abs_dist.__class__.__name__ == SourceDistribution.__name__
 
 
 def test_safe_file_cache():

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -143,7 +143,8 @@ def test_link_and_ireq():
 
 def test_path_and_url():
     path = "/path/to/file"
-    prefix = "/C:" if os.name == "nt" else ""
+    prefix, _ = os.path.splitdrive(os.getcwd())
+    prefix = "/{0}".format(prefix) if prefix else ""
     url = "file://{0}{1}".format(prefix, path)
     assert is_file_url(Link(url))
     assert path_to_url(path) == url

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -349,7 +349,7 @@ def test_wheelbuilder(tmpdir, PipCommand):
         "trusted_hosts": pip_options.trusted_hosts,
         "session": session,
     }
-    if pip_version >= parse_version("19.1.1"):
+    if pip_version > parse_version("19.1.1"):
         finder_args["candidate_evaluator"] = CandidateEvaluator(
             target_python=None,
             prefer_binary=False,

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -349,7 +349,7 @@ def test_wheelbuilder(tmpdir, PipCommand):
         "trusted_hosts": pip_options.trusted_hosts,
         "session": session,
     }
-    if pip_version > parse_version("19.1.1"):
+    if parse_version(pip_version) > parse_version("19.1.1"):
         finder_args["candidate_evaluator"] = CandidateEvaluator(
             target_python=None,
             prefer_binary=False,

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -1,60 +1,61 @@
 # -*- coding=utf-8 -*-
 from __future__ import absolute_import, unicode_literals
+
 import os
+import sys
+import textwrap
+
+import pytest
+import six
+
 from pip_shims import (
-    _strip_extras,
-    cmdoptions,
+    FAVORITE_HASH,
+    USER_CACHE_DIR,
+    BadCommand,
+    BestVersionAlreadyInstalled,
+    CandidateEvaluator,
     Command,
+    CommandError,
     ConfigOptionParser,
     DistributionNotFound,
-    FAVORITE_HASH,
     FormatControl,
+    FrozenRequirement,
+    InstallationError,
+    InstallRequirement,
+    Link,
+    PackageFinder,
+    PipError,
+    PreviousBuildDirError,
+    PyPI,
+    RequirementPreparer,
+    RequirementSet,
+    RequirementsFileParseError,
+    RequirementTracker,
+    Resolver,
+    SafeFileCache,
+    UninstallationError,
+    VcsSupport,
+    Wheel,
+    WheelBuilder,
+    WheelCache,
+    _strip_extras,
+    cmdoptions,
     get_installed_distributions,
     index_group,
-    InstallRequirement,
+    install_req_from_editable,
+    install_req_from_line,
     is_archive_file,
     is_file_url,
-    unpack_url,
     is_installable_dir,
-    Link,
     make_abstract_dist,
     make_option_group,
-    PackageFinder,
     parse_requirements,
     parse_version,
     path_to_url,
     pip_version,
-    PipError,
-    RequirementPreparer,
-    RequirementSet,
-    RequirementTracker,
-    Resolver,
-    SafeFileCache,
+    unpack_url,
     url_to_path,
-    USER_CACHE_DIR,
-    VcsSupport,
-    Wheel,
-    WheelCache,
-    WheelBuilder,
-    install_req_from_editable,
-    install_req_from_line,
-    FrozenRequirement,
-    DistributionNotFound,
-    PipError,
-    InstallationError,
-    UninstallationError,
-    DistributionNotFound,
-    RequirementsFileParseError,
-    BestVersionAlreadyInstalled,
-    BadCommand,
-    CommandError,
-    PreviousBuildDirError,
-    PyPI,
 )
-import pytest
-import six
-import sys
-import textwrap
 
 STRING_TYPES = (str,)
 if sys.version_info < (3, 0):
@@ -75,9 +76,7 @@ def test_command(PipCommand):
     pip_command.parser.add_option(cmdoptions.only_binary())
     assert make_option_group
     assert index_group
-    index_opts = cmdoptions.make_option_group(
-        cmdoptions.index_group, pip_command.parser
-    )
+    index_opts = cmdoptions.make_option_group(cmdoptions.index_group, pip_command.parser)
     pip_command.parser.insert_option_group(0, index_opts)
     assert "pypi" in pip_command.parser.option_groups[0].get_option("-i").default
 
@@ -103,7 +102,6 @@ def test_configparser(PipCommand):
         (CommandError, Exception),
         (PreviousBuildDirError, Exception),
     ],
-
 )
 def test_exceptions(exceptionclass, baseclass):
     assert issubclass(exceptionclass, baseclass)
@@ -168,7 +166,8 @@ def test_is_installable(tmpdir):
             name="Test Project",
             version="0.0.0"
         )
-    """),
+    """
+        ),
         encoding="utf-8",
     )
     assert is_installable_dir(temp_dir.strpath)
@@ -223,9 +222,11 @@ def test_resolution(tmpdir, PipCommand):
     assert "pythonhosted" in best_version.location.url
     req_file = tmpdir.mkdir("req_dir").join("requirements.txt")
     req_file.write_text(
-        textwrap.dedent("""
+        textwrap.dedent(
+            """
             requests>=2.18
-        """),
+        """
+        ),
         encoding="utf-8",
     )
     parsed_ireq = parse_requirements(
@@ -305,6 +306,7 @@ def test_safe_file_cache():
 
 def test_frozen_req():
     import pkg_resources
+
     req = pkg_resources.Requirement.parse("requests==2.19.1")
     fr = FrozenRequirement("requests", req, False)
     assert fr is not None
@@ -328,7 +330,7 @@ def test_wheel():
 
 @pytest.mark.skipif(
     (sys.version_info > (3, 0) and sys.version_info < (3, 5)),
-    reason="Can't build a wheel for six on python 3.5"
+    reason="Can't build a wheel for six on python 3.5",
 )
 def test_wheelbuilder(tmpdir, PipCommand):
     output_dir = tmpdir.join("output")
@@ -341,13 +343,22 @@ def test_wheelbuilder(tmpdir, PipCommand):
     CACHE_DIR = tmpdir.mkdir("CACHE_DIR")
     pip_options.cache_dir = CACHE_DIR.strpath
     session = pip_command._build_session(pip_options)
-    finder = PackageFinder(
-        find_links=pip_options.find_links,
-        index_urls=[pip_options.index_url],
-        trusted_hosts=pip_options.trusted_hosts,
-        allow_all_prereleases=False,
-        session=session,
-    )
+    finder_args = {
+        "find_links": pip_options.find_links,
+        "index_urls": [pip_options.index_url],
+        "trusted_hosts": pip_options.trusted_hosts,
+        "session": session,
+    }
+    if pip_version >= parse_version("19.1.1"):
+        finder_args["candidate_evaluator"] = CandidateEvaluator(
+            target_python=None,
+            prefer_binary=False,
+            allow_all_prereleases=False,
+            ignore_requires_python=False,
+        )
+    else:
+        finder_args["allow_all_prereleases"] = False
+    finder = PackageFinder(**finder_args)
     build_dir = tmpdir.mkdir("build_dir")
     source_dir = tmpdir.mkdir("source_dir")
     download_dir = tmpdir.mkdir("download_dir")
@@ -360,7 +371,9 @@ def test_wheelbuilder(tmpdir, PipCommand):
         "wheel_download_dir": wheel_download_dir.strpath,
         "wheel_cache": wheel_cache,
     }
-    ireq = InstallRequirement.from_editable("git+https://github.com/urllib3/urllib3@1.23#egg=urllib3")
+    ireq = InstallRequirement.from_editable(
+        "git+https://github.com/urllib3/urllib3@1.23#egg=urllib3"
+    )
     ireq.populate_link(finder, False, False)
     ireq.ensure_has_source_dir(kwargs["src_dir"])
     # Ensure the remote artifact is downloaded locally. For wheels, it is
@@ -369,7 +382,7 @@ def test_wheelbuilder(tmpdir, PipCommand):
     unpack_kwargs = {
         "only_download": ireq.is_wheel,
         "session": session,
-        "hashes": ireq.hashes(True)
+        "hashes": ireq.hashes(True),
     }
     if parse_version(pip_version) >= parse_version("10"):
         unpack_kwargs["progress_bar"] = False
@@ -400,9 +413,11 @@ def test_pypi():
 
 def test_dev_pkgs():
     from pip_shims.shims import DEV_PKGS
+
     assert "pip" in DEV_PKGS and "wheel" in DEV_PKGS
 
 
 def test_stdlib_pkgs():
     from pip_shims.shims import stdlib_pkgs
+
     assert "argparse" in stdlib_pkgs


### PR DESCRIPTION
Fix VcsSupport import and PackageFinder test

- Add `CandidateEvaluator` import
- Update `PackageFinder` test to use `CandidateEvaluator` when on
  `pip>=19.1`
- Update `VcsSupport` import on `pip>19.1.1` to point at new path
- Fixes #27
- Fixes #28