### PR TITLE
This change gets pipenv working with pip 22.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
         os: [macos, ubuntu, windows]
 
     steps:

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,6 +16,7 @@ PIP_VERSIONS = [
     "pip~=21.1.0",
     "pip~=21.2.0",
     "pip~=21.3.0",
+    "pip~=22.0.0",
     "git+https://github.com/pypa/pip.git",
 ]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -104,7 +104,7 @@ exclude =
     .cache,
     .eggs,
     setup.py,
-max-complexity=13
+max-complexity=16
 
 [mypy]
 ignore_missing_imports=true

--- a/src/pip_shims/__init__.py
+++ b/src/pip_shims/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding=utf-8 -*-
 """
-This library is a set of compatibilty access shims to the ``pip`` internal API.
+This library is a set of compatibility access shims to the ``pip`` internal API.
 It provides compatibility with pip versions 8.0 through the current release. The
 shims are provided using a lazy import strategy by hacking a module by overloading
 a class instance's ``getattr`` method. This library exists due to my constant

--- a/src/pip_shims/compat.py
+++ b/src/pip_shims/compat.py
@@ -744,7 +744,7 @@ def shim_unpack(
     downloader_provider = resolve_possible_shim(downloader_provider)
     tempdir_manager_provider = resolve_possible_shim(tempdir_manager_provider)
     required_args = inspect.getargs(unpack_fn.__code__).args  # type: ignore
-    unpack_kwargs = {"download_dir": download_dir, "verbosity": verbosity}
+    unpack_kwargs = {"download_dir": download_dir}
     with tempdir_manager_provider():
         if ireq:
             if not link and ireq.link:
@@ -771,6 +771,8 @@ def shim_unpack(
             assert session is not None
             assert progress_bar is not None
             unpack_kwargs[arg_name] = downloader_provider(session, progress_bar)
+        if "verbosity" in required_args:
+            unpack_kwargs["verbosity"] = verbosity
         return unpack_fn(**unpack_kwargs)  # type: ignore
 
 

--- a/src/pip_shims/compat.py
+++ b/src/pip_shims/compat.py
@@ -816,6 +816,7 @@ def make_preparer(
     require_hashes=None,  # type: Optional[bool]
     use_user_site=None,  # type: Optional[bool]
     req_tracker=None,  # type: Optional[Union[TReqTracker, TShimmedFunc]]
+    build_tracker=None,  # type: Optional[Union[TBuildTracker, TShimmedFunc]]
     install_cmd_provider=None,  # type: Optional[TShimmedFunc]
     downloader_provider=None,  # type: Optional[TShimmedFunc]
     install_cmd=None,  # type: Optional[TCommandInstance]
@@ -856,6 +857,8 @@ def make_preparer(
         preparing requirements
     :param Optional[Union[TReqTracker, TShimmedFunc]] req_tracker: The requirement
         tracker to use for building packages, defaults to None
+    :param Optional[Union[TBuildTracker, TShimmedFunc]] build_tracker: The build
+        tracker to use for building packages, defaults to None and fallsback to req_tracker.
     :param Optional[TShimmedFunc] downloader_provider: A downloader provider
     :param Optional[TCommandInstance] install_cmd: The install command used to create
         the finder, session, and options if needed, defaults to None
@@ -936,6 +939,10 @@ def make_preparer(
         if "req_tracker" in required_args:
             req_tracker = tracker_ctx if req_tracker is None else req_tracker
             preparer_args["req_tracker"] = req_tracker
+        if "build_tracker" in required_args:
+            req_tracker = tracker_ctx if req_tracker is None else req_tracker
+            build_tracker = req_tracker if build_tracker is None else build_tracker
+            preparer_args["build_tracker"] = build_tracker
         preparer_args["lazy_wheel"] = True
         result = call_function_with_correct_args(preparer_fn, **preparer_args)
         yield result

--- a/src/pip_shims/compat.py
+++ b/src/pip_shims/compat.py
@@ -708,6 +708,7 @@ def shim_unpack(
     only_download=None,  # type: Optional[bool]
     downloader_provider=None,  # type: Optional[TShimmedFunc]
     session=None,  # type: Optional[Any]
+    verbosity=0,  # type: Optional[int]
 ):
     # (...) -> None
     """
@@ -735,6 +736,7 @@ def shim_unpack(
         to instantiate, if applicable.
     :param Optional[`~requests.Session`] session: A PipSession instance, defaults to
         None.
+    :param Optional[int] verbosity: 1 or 0 to indicate verbosity flag, defaults to 0.
     :return: The result of unpacking the url.
     :rtype: None
     """
@@ -742,7 +744,7 @@ def shim_unpack(
     downloader_provider = resolve_possible_shim(downloader_provider)
     tempdir_manager_provider = resolve_possible_shim(tempdir_manager_provider)
     required_args = inspect.getargs(unpack_fn.__code__).args  # type: ignore
-    unpack_kwargs = {"download_dir": download_dir}
+    unpack_kwargs = {"download_dir": download_dir, "verbosity": verbosity}
     with tempdir_manager_provider():
         if ireq:
             if not link and ireq.link:

--- a/src/pip_shims/compat.py
+++ b/src/pip_shims/compat.py
@@ -55,6 +55,7 @@ if MYPY_RUNNING:
     TFinder = TypeVar("TFinder")
     TResolver = TypeVar("TResolver")
     TReqTracker = TypeVar("TReqTracker")
+    TBuildTracker = TypeVar("TBuildTracker")
     TReqSet = TypeVar("TReqSet")
     TLink = TypeVar("TLink")
     TSession = TypeVar("TSession", bound=Session)
@@ -891,7 +892,6 @@ def make_preparer(
         raise TypeError("No requirement tracker and no req tracker generator found!")
     if "downloader" in required_args and not downloader_provider:
         raise TypeError("no downloader provided, but one is required to continue!")
-    req_tracker_fn = resolve_possible_shim(req_tracker_fn)
     pip_options_created = options is None
     session_is_required = "session" in required_args
     finder_is_required = "finder" in required_args
@@ -934,6 +934,7 @@ def make_preparer(
         preparer_args["in_tree_build"] = True
     if "verbosity" in required_args:
         preparer_args["verbosity"] = verbosity
+    req_tracker_fn = resolve_possible_shim(req_tracker_fn)
     req_tracker_fn = nullcontext if not req_tracker_fn else req_tracker_fn
     with req_tracker_fn() as tracker_ctx:
         if "req_tracker" in required_args:

--- a/src/pip_shims/compat.py
+++ b/src/pip_shims/compat.py
@@ -820,6 +820,7 @@ def make_preparer(
     downloader_provider=None,  # type: Optional[TShimmedFunc]
     install_cmd=None,  # type: Optional[TCommandInstance]
     finder_provider=None,  # type: Optional[TShimmedFunc]
+    verbosity=0,  # type: Optional[int]
 ):
     # (...) -> ContextManager
     """
@@ -928,6 +929,8 @@ def make_preparer(
         preparer_args["downloader"] = downloader_provider(session, progress_bar)
     if "in_tree_build" in required_args:
         preparer_args["in_tree_build"] = True
+    if "verbosity" in required_args:
+        preparer_args["verbosity"] = verbosity
     req_tracker_fn = nullcontext if not req_tracker_fn else req_tracker_fn
     with req_tracker_fn() as tracker_ctx:
         if "req_tracker" in required_args:

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -303,9 +303,6 @@ def test_resolution(tmpdir, PipCommand):
             "ignore_installed": True,
             "use_user_site": False,
         }
-        if parse_version(pip_version) >= parse_version("22.0"):
-            #preparer_kwargs['verbosity'] = 1
-            pass
         if (
             parse_version("19.3")
             <= parse_version(pip_version)

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -246,7 +246,8 @@ def test_resolution(tmpdir, PipCommand):
             "session": session,
             "allow_all_prereleases": False,
         }
-        # finder_args["allow_all_prereleases"] = False
+        if parse_version(pip_version) >= parse_version("22.0.0"):
+            finder_args["use_deprecated_html5lib"] = False
     finder = PackageFinder(**finder_args)
     ireq = InstallRequirement.from_line("requests>=2.18")
     if install_req_from_line:
@@ -432,7 +433,8 @@ def test_wheelbuilder(tmpdir, PipCommand):
             "session": session,
             "allow_all_prereleases": False,
         }
-        # finder_args["allow_all_prereleases"] = False
+        if parse_version(pip_version) >= parse_version("22.0.0"):
+            finder_args["use_deprecated_html5lib"] = False
     finder = PackageFinder(**finder_args)
     build_dir = tmpdir.mkdir("build_dir")
     source_dir = tmpdir.mkdir("source_dir")

--- a/tests/test_instances.py
+++ b/tests/test_instances.py
@@ -238,6 +238,8 @@ def test_resolution(tmpdir, PipCommand):
                 "ignore_requires_python": selection_prefs.ignore_requires_python,
             }
         )
+        if parse_version(pip_version) >= parse_version("22.0"):
+            finder_args["use_deprecated_html5lib"] = False
     else:
         finder_args = {
             "find_links": pip_options.find_links,
@@ -246,8 +248,6 @@ def test_resolution(tmpdir, PipCommand):
             "session": session,
             "allow_all_prereleases": False,
         }
-        if parse_version(pip_version) >= parse_version("22.0.0"):
-            finder_args["use_deprecated_html5lib"] = False
     finder = PackageFinder(**finder_args)
     ireq = InstallRequirement.from_line("requests>=2.18")
     if install_req_from_line:
@@ -303,6 +303,9 @@ def test_resolution(tmpdir, PipCommand):
             "ignore_installed": True,
             "use_user_site": False,
         }
+        if parse_version(pip_version) >= parse_version("22.0"):
+            #preparer_kwargs['verbosity'] = 1
+            pass
         if (
             parse_version("19.3")
             <= parse_version(pip_version)
@@ -425,6 +428,8 @@ def test_wheelbuilder(tmpdir, PipCommand):
                 "ignore_requires_python": selection_prefs.ignore_requires_python,
             }
         )
+        if parse_version(pip_version) >= parse_version("22.0"):
+            finder_args["use_deprecated_html5lib"] = False
     else:
         finder_args = {
             "find_links": pip_options.find_links,
@@ -433,8 +438,6 @@ def test_wheelbuilder(tmpdir, PipCommand):
             "session": session,
             "allow_all_prereleases": False,
         }
-        if parse_version(pip_version) >= parse_version("22.0.0"):
-            finder_args["use_deprecated_html5lib"] = False
     finder = PackageFinder(**finder_args)
     build_dir = tmpdir.mkdir("build_dir")
     source_dir = tmpdir.mkdir("source_dir")


### PR DESCRIPTION
Pip 22.x requires a verbosity argument
Pip trunk renames the `req_tracker` to be the `build_tracker`
Drop py3.6 support

Pipenv Ref:  https://github.com/pypa/pipenv/pull/4969/files
Requirementslib build also will depend on this change soon.