### PR TITLE
Resolve issue of build_tracker being None at runtime with pip 22.1

### DIFF
--- a/news/81.feature.rst
+++ b/news/81.feature.rst
@@ -1,0 +1,1 @@
+Resolve issue of ``build_tracker`` being ``None`` at runtime with ``pip>=22.1`` when using ``pip_shims``.

--- a/src/pip_shims/compat.py
+++ b/src/pip_shims/compat.py
@@ -945,9 +945,10 @@ def make_preparer(
         preparer_args["verbosity"] = verbosity
     if "check_build_deps" in required_args:
         preparer_args["check_build_deps"] = check_build_deps
-    req_tracker_fn = resolve_possible_shim(req_tracker_fn)
-    req_tracker_fn = nullcontext if not req_tracker_fn else req_tracker_fn
+
     if "build_tracker" in required_args:
+        build_tracker_fn = resolve_possible_shim(build_tracker_fn)
+        build_tracker_fn = nullcontext if not build_tracker_fn else build_tracker_fn
         with build_tracker_fn() as tracker_ctx:
             build_tracker = tracker_ctx if build_tracker is None else build_tracker
             preparer_args["build_tracker"] = build_tracker
@@ -955,6 +956,8 @@ def make_preparer(
             result = call_function_with_correct_args(preparer_fn, **preparer_args)
             yield result
     if "req_tracker" in required_args:
+        req_tracker_fn = resolve_possible_shim(req_tracker_fn)
+        req_tracker_fn = nullcontext if not req_tracker_fn else req_tracker_fn
         with req_tracker_fn() as tracker_ctx:
             req_tracker = tracker_ctx if req_tracker is None else req_tracker
             preparer_args["req_tracker"] = req_tracker

--- a/src/pip_shims/compat.py
+++ b/src/pip_shims/compat.py
@@ -303,24 +303,29 @@ def temp_environ():
 
 
 @contextlib.contextmanager
-def get_requirement_tracker(req_tracker_creator=None):
-    # type: (Optional[Callable]) -> Generator[Optional[TReqTracker], None, None]
-    root = os.environ.get("PIP_REQ_TRACKER")
-    if not req_tracker_creator:
+def get_tracker(tracker_creator=None, tracker_type="REQ"):
+    # type: (Optional[Callable]) -> Generator[Optional[TReqTracker, TBuildTracker], None, None]
+    env_var = "PIP_REQ_TRACKER"
+    prefix = "req-tracker"
+    if tracker_type == "BUILD":  # Replaced the req tracker in pip>=22.1
+        env_var = "PIP_BUILD_TRACKER"
+        prefix = "build-tracker"
+    root = os.environ.get(env_var)
+    if not tracker_creator:
         yield None
     else:
         req_tracker_args = []
-        _, required_args = get_method_args(req_tracker_creator.__init__)  # type: ignore
+        _, required_args = get_method_args(tracker_creator.__init__)  # type: ignore
         with ExitStack() as ctx:
             if root is None:
-                root = ctx.enter_context(TemporaryDirectory(prefix="req-tracker"))
+                root = ctx.enter_context(TemporaryDirectory(prefix=prefix))
                 if root:
                     root = str(root)
                     ctx.enter_context(temp_environ())
-                    os.environ["PIP_REQ_TRACKER"] = root
+                    os.environ[env_var] = root
             if required_args is not None and "root" in required_args:
                 req_tracker_args.append(root)
-            with req_tracker_creator(*req_tracker_args) as tracker:
+            with tracker_creator(*req_tracker_args) as tracker:
                 yield tracker
 
 
@@ -804,6 +809,7 @@ def _ensure_finder(
 @contextlib.contextmanager
 def make_preparer(
     preparer_fn,  # type: TShimmedFunc
+    build_tracker_fn=None,  # type: Optional[TShimmedFunc]
     req_tracker_fn=None,  # type: Optional[TShimmedFunc]
     build_dir=None,  # type: Optional[str]
     src_dir=None,  # type: Optional[str]
@@ -891,6 +897,8 @@ def make_preparer(
     required_args, required_kwargs = get_allowed_args(preparer_fn)  # type: ignore
     if not req_tracker and not req_tracker_fn and "req_tracker" in required_args:
         raise TypeError("No requirement tracker and no req tracker generator found!")
+    if not build_tracker and not build_tracker_fn and "build_tracker" in required_args:
+        raise TypeError("No build tracker and no build tracker generator found!")
     if "downloader" in required_args and not downloader_provider:
         raise TypeError("no downloader provided, but one is required to continue!")
     pip_options_created = options is None
@@ -939,17 +947,20 @@ def make_preparer(
         preparer_args["check_build_deps"] = check_build_deps
     req_tracker_fn = resolve_possible_shim(req_tracker_fn)
     req_tracker_fn = nullcontext if not req_tracker_fn else req_tracker_fn
-    with req_tracker_fn() as tracker_ctx:
-        if "req_tracker" in required_args:
+    if "build_tracker" in required_args:
+        with build_tracker_fn() as tracker_ctx:
+            build_tracker = tracker_ctx if build_tracker is None else build_tracker
+            preparer_args["build_tracker"] = build_tracker
+            preparer_args["lazy_wheel"] = True
+            result = call_function_with_correct_args(preparer_fn, **preparer_args)
+            yield result
+    if "req_tracker" in required_args:
+        with req_tracker_fn() as tracker_ctx:
             req_tracker = tracker_ctx if req_tracker is None else req_tracker
             preparer_args["req_tracker"] = req_tracker
-        if "build_tracker" in required_args:
-            req_tracker = tracker_ctx if req_tracker is None else req_tracker
-            build_tracker = req_tracker if build_tracker is None else build_tracker
-            preparer_args["build_tracker"] = build_tracker
-        preparer_args["lazy_wheel"] = True
-        result = call_function_with_correct_args(preparer_fn, **preparer_args)
-        yield result
+            preparer_args["lazy_wheel"] = True
+            result = call_function_with_correct_args(preparer_fn, **preparer_args)
+            yield result
 
 
 @contextlib.contextmanager

--- a/src/pip_shims/models.py
+++ b/src/pip_shims/models.py
@@ -56,47 +56,6 @@ if MYPY_RUNNING:
     )
 
 
-PIP_VERSION_SET = {
-    "7.0.0",
-    "7.0.1",
-    "7.0.2",
-    "7.0.3",
-    "7.1.0",
-    "7.1.1",
-    "7.1.2",
-    "8.0.0",
-    "8.0.1",
-    "8.0.2",
-    "8.0.3",
-    "8.1.0",
-    "8.1.1",
-    "8.1.2",
-    "9.0.0",
-    "9.0.1",
-    "9.0.2",
-    "9.0.3",
-    "10.0.0",
-    "10.0.1",
-    "18.0",
-    "18.1",
-    "19.0",
-    "19.0.1",
-    "19.0.2",
-    "19.0.3",
-    "19.1",
-    "19.1.1",
-    "19.2",
-    "19.2.1",
-    "19.2.2",
-    "19.2.3",
-    "19.3",
-    "19.3.1",
-    "20.0",
-    "20.0.1",
-    "20.0.2",
-}
-
-
 ImportTypesBase = collections.namedtuple(
     "ImportTypes", ["FUNCTION", "CLASS", "MODULE", "CONTEXTMANAGER"]
 )
@@ -992,6 +951,9 @@ RequirementPreparer.create_path("operations.prepare.RequirementPreparer", "7", "
 RequirementSet = ShimmedPathCollection("RequirementSet", ImportTypes.CLASS)
 RequirementSet.create_path("req.req_set.RequirementSet", "7.0.0", "9999")
 
+BuildTracker = ShimmedPathCollection("BuildTracker", ImportTypes.CONTEXTMANAGER)
+BuildTracker.create_path(".operations.build.build_tracker.BuildTracker", "22.1", "9999")
+
 RequirementTracker = ShimmedPathCollection(
     "RequirementTracker", ImportTypes.CONTEXTMANAGER
 )
@@ -1021,10 +983,17 @@ get_requirement_tracker = ShimmedPathCollection(
     "get_requirement_tracker", ImportTypes.CONTEXTMANAGER
 )
 get_requirement_tracker.set_default(
-    functools.partial(compat.get_requirement_tracker, RequirementTracker.shim())
+    functools.partial(compat.get_tracker, RequirementTracker.shim())
 )
 get_requirement_tracker.create_path(
     "req.req_tracker.get_requirement_tracker", "7.0.0", "9999"
+)
+get_build_tracker = ShimmedPathCollection("get_build_tracker", ImportTypes.CONTEXTMANAGER)
+get_build_tracker.set_default(
+    functools.partial(compat.get_tracker, BuildTracker.shim(), tracker_type="BUILD")
+)
+get_build_tracker.create_path(
+    "operations.build.build_tracker.get_build_tracker", "21.1", "9999"
 )
 
 Resolver = ShimmedPathCollection("Resolver", ImportTypes.CLASS)
@@ -1137,6 +1106,7 @@ make_preparer.set_default(
         install_cmd_provider=InstallCommand,
         preparer_fn=RequirementPreparer,
         downloader_provider=Downloader,
+        build_tracker_fn=get_build_tracker,
         req_tracker_fn=get_requirement_tracker,
         finder_provider=get_package_finder,
     )

--- a/src/pip_shims/models.py
+++ b/src/pip_shims/models.py
@@ -952,7 +952,7 @@ RequirementSet = ShimmedPathCollection("RequirementSet", ImportTypes.CLASS)
 RequirementSet.create_path("req.req_set.RequirementSet", "7.0.0", "9999")
 
 BuildTracker = ShimmedPathCollection("BuildTracker", ImportTypes.CONTEXTMANAGER)
-BuildTracker.create_path(".operations.build.build_tracker.BuildTracker", "22.1", "9999")
+BuildTracker.create_path("operations.build.build_tracker.BuildTracker", "22.1", "9999")
 
 RequirementTracker = ShimmedPathCollection(
     "RequirementTracker", ImportTypes.CONTEXTMANAGER
@@ -993,7 +993,7 @@ get_build_tracker.set_default(
     functools.partial(compat.get_tracker, BuildTracker.shim(), tracker_type="BUILD")
 )
 get_build_tracker.create_path(
-    "operations.build.build_tracker.get_build_tracker", "21.1", "9999"
+    "operations.build.build_tracker.get_build_tracker", "7.0.0", "9999"
 )
 
 Resolver = ShimmedPathCollection("Resolver", ImportTypes.CLASS)


### PR DESCRIPTION
Issue affecting `requirementslib` and default instantiation of values in pip 22.1.x