### PR TITLE
Make these imports easier to patch out to vendor'd packaging lib.

### DIFF
--- a/news/82.trivial.rst
+++ b/news/82.trivial.rst
@@ -1,0 +1,1 @@
+Change style of ``packaging`` import for downstream ``pipenv`` to be able to patch this more easily.

--- a/src/pip_shims/models.py
+++ b/src/pip_shims/models.py
@@ -36,7 +36,7 @@ from .utils import (
 )
 
 if MYPY_RUNNING:
-    import packaging.version
+    from packaging.version import _BaseVersion
 
     Module = types.ModuleType
     from typing import (  # noqa:F811
@@ -156,7 +156,7 @@ class PipVersion(Sequence):
         return self.version_tuple[item]
 
     def _parse(self):
-        # type: () -> packaging.version._BaseVersion
+        # type: () -> _BaseVersion
         return parse_version(self.version)
 
     def __hash__(self):

--- a/src/pip_shims/utils.py
+++ b/src/pip_shims/utils.py
@@ -11,7 +11,7 @@ import sys
 from collections.abc import Callable
 from functools import wraps
 
-import packaging.version
+from packaging.version import _BaseVersion, parse
 
 from .environment import MYPY_RUNNING
 
@@ -107,10 +107,10 @@ def _parse(version):
 
 @memoize
 def parse_version(version):
-    # type: (str) -> packaging.version._BaseVersion
+    # type: (str) -> _BaseVersion
     if not isinstance(version, STRING_TYPES):
         raise TypeError("Can only derive versions from string, got {!r}".format(version))
-    return packaging.version.parse(version)
+    return parse(version)
 
 
 @memoize


### PR DESCRIPTION
Right now there is a right in pipenv where we vendor packaging, ignore it and pip uses its own vendor'd packaging and we delay importing it until after the virtualenv is created so we can use the packaging from there.   I would like to just have all of pipenv patched to use the vendor'd pip's version of packaging and drop the other import usages to ensure compatibility. It is hard because of these type of imports in requirements lib because there is not a great way to sub out this style import without also changing the usages.